### PR TITLE
Set the 'z' values of constant-rate orders high

### DIFF
--- a/src/strategy-management/Toolkit.ts
+++ b/src/strategy-management/Toolkit.ts
@@ -56,7 +56,7 @@ import {
 } from './utils';
 
 // Encoder utility
-import { decodeOrder } from '../utils/encoders';
+import { decodeOrder, LARGE_Z } from '../utils/encoders';
 import {
   encodedStrategyStrToBN,
   matchActionBNToStr,
@@ -64,8 +64,6 @@ import {
   ordersMapStrToBN,
   tradeActionStrToBN,
 } from '../utils';
-
-const LARGE_Z = BigNumber.from(2).pow(112);
 
 /**
  * Enum representing options for the marginal price parameter of the function.

--- a/src/strategy-management/Toolkit.ts
+++ b/src/strategy-management/Toolkit.ts
@@ -65,6 +65,8 @@ import {
   tradeActionStrToBN,
 } from '../utils';
 
+const LARGE_Z = BigNumber.from(2).pow(112);
+
 /**
  * Enum representing options for the marginal price parameter of the function.
  */
@@ -807,11 +809,14 @@ export class Toolkit {
       newEncodedStrategy.order0.B = encodedBN.order0.B;
     }
 
-    if (buyBudget !== undefined) {
+    if (newEncodedStrategy.order1.A.isZero()) {
+        newEncodedStrategy.order1.z = LARGE_Z;
+    } else if (buyBudget !== undefined) {
       if (
         buyMarginalPrice === undefined ||
         buyMarginalPrice === MarginalPriceOptions.reset ||
-        encodedBN.order1.y.isZero()
+        encodedBN.order1.y.isZero() ||
+        encodedBN.order1.A.isZero()
       ) {
         newEncodedStrategy.order1.z = newEncodedStrategy.order1.y;
       } else if (buyMarginalPrice === MarginalPriceOptions.maintain) {
@@ -824,11 +829,14 @@ export class Toolkit {
       }
     }
 
-    if (sellBudget !== undefined) {
+    if (newEncodedStrategy.order0.A.isZero()) {
+        newEncodedStrategy.order0.z = LARGE_Z;
+    } else if (sellBudget !== undefined) {
       if (
         sellMarginalPrice === undefined ||
         sellMarginalPrice === MarginalPriceOptions.reset ||
-        encodedBN.order0.y.isZero()
+        encodedBN.order0.y.isZero() ||
+        encodedBN.order0.A.isZero()
       ) {
         newEncodedStrategy.order0.z = newEncodedStrategy.order0.y;
       } else if (sellMarginalPrice === MarginalPriceOptions.maintain) {
@@ -842,10 +850,18 @@ export class Toolkit {
     }
 
     if (buyPriceLow !== undefined || buyPriceHigh !== undefined) {
-      newEncodedStrategy.order1.z = newEncodedStrategy.order1.y;
+      if (newEncodedStrategy.order1.A.isZero()) {
+        newEncodedStrategy.order1.z = LARGE_Z;
+      } else {
+        newEncodedStrategy.order1.z = newEncodedStrategy.order1.y;
+      }
     }
     if (sellPriceLow !== undefined || sellPriceHigh !== undefined) {
-      newEncodedStrategy.order0.z = newEncodedStrategy.order0.y;
+      if (newEncodedStrategy.order0.A.isZero()) {
+        newEncodedStrategy.order0.z = LARGE_Z;
+      } else {
+        newEncodedStrategy.order0.z = newEncodedStrategy.order0.y;
+      }
     }
 
     if (

--- a/src/utils/encoders.ts
+++ b/src/utils/encoders.ts
@@ -1,13 +1,13 @@
 import { BigNumber, Decimal, BnToDec, DecToBn, ONE } from './numerics';
 import { DecodedOrder, EncodedOrder } from '../common/types';
 
+const LARGE_Z = BigNumber.from(2).pow(112);
+
 function bitLength(value: BigNumber) {
   return value.gt(0)
     ? Decimal.log2(value.toString()).add(1).floor().toNumber()
     : 0;
 }
-
-export const LARGE_Z = BigNumber.from(2).pow(112);
 
 export const encodeRate = (value: Decimal) => {
   const data = DecToBn(value.sqrt().mul(ONE).floor());

--- a/src/utils/encoders.ts
+++ b/src/utils/encoders.ts
@@ -1,7 +1,7 @@
 import { BigNumber, Decimal, BnToDec, DecToBn, ONE } from './numerics';
 import { DecodedOrder, EncodedOrder } from '../common/types';
 
-const LARGE_Z = BigNumber.from(2).pow(112);
+const LARGE_Z = BigNumber.from(2).pow(112).sub(1);
 
 function bitLength(value: BigNumber) {
   return value.gt(0)

--- a/src/utils/encoders.ts
+++ b/src/utils/encoders.ts
@@ -7,6 +7,8 @@ function bitLength(value: BigNumber) {
     : 0;
 }
 
+export const LARGE_Z = BigNumber.from(2).pow(112);
+
 export const encodeRate = (value: Decimal) => {
   const data = DecToBn(value.sqrt().mul(ONE).floor());
   const length = bitLength(data.div(ONE));
@@ -51,7 +53,7 @@ export const encodeOrder = (order: DecodedOrder): EncodedOrder => {
   const M = DecToBn(encodeRate(marginalRate));
   return {
     y: y,
-    z: H.eq(M) ? y : y.mul(H.sub(L)).div(M.sub(L)),
+    z: H.eq(L) ? LARGE_Z : H.eq(M) ? y : y.mul(H.sub(L)).div(M.sub(L)),
     A: encodeFloat(H.sub(L)),
     B: encodeFloat(L),
   };

--- a/tests/encoders.spec.ts
+++ b/tests/encoders.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { encodeOrder, decodeOrder } from '../src/utils/encoders';
+import { encodeOrder, decodeOrder, LARGE_Z } from '../src/utils/encoders';
 import {
   buildStrategyObject,
   encodeStrategy,
@@ -43,7 +43,7 @@ describe('encoders', () => {
       };
       const encodedOrder = encodeOrder(order);
       expect(encodedOrder.y.toString()).to.equal('100');
-      expect(encodedOrder.z.toString()).to.equal('100');
+      expect(encodedOrder.z.toString()).to.equal(`${LARGE_Z}`);
       expect(encodedOrder.A.toString()).to.equal('0');
       expect(encodedOrder.B.toString()).to.equal('199032864766430');
     });

--- a/tests/encoders.spec.ts
+++ b/tests/encoders.spec.ts
@@ -43,7 +43,7 @@ describe('encoders', () => {
       };
       const encodedOrder = encodeOrder(order);
       expect(encodedOrder.y.toString()).to.equal('100');
-      expect(encodedOrder.z.toString()).to.equal(`${BigNumber.from(2).pow(112)}`);
+      expect(encodedOrder.z.toString()).to.equal(`${BigNumber.from(2).pow(112).sub(1)}`);
       expect(encodedOrder.A.toString()).to.equal('0');
       expect(encodedOrder.B.toString()).to.equal('199032864766430');
     });

--- a/tests/encoders.spec.ts
+++ b/tests/encoders.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { encodeOrder, decodeOrder, LARGE_Z } from '../src/utils/encoders';
+import { encodeOrder, decodeOrder } from '../src/utils/encoders';
 import {
   buildStrategyObject,
   encodeStrategy,
@@ -43,7 +43,7 @@ describe('encoders', () => {
       };
       const encodedOrder = encodeOrder(order);
       expect(encodedOrder.y.toString()).to.equal('100');
-      expect(encodedOrder.z.toString()).to.equal(`${LARGE_Z}`);
+      expect(encodedOrder.z.toString()).to.equal(`${BigNumber.from(2).pow(112)}`);
       expect(encodedOrder.A.toString()).to.equal('0');
       expect(encodedOrder.B.toString()).to.equal('199032864766430');
     });


### PR DESCRIPTION
Note that this change will make the creation of a disposable ("single-order") strategy slightly more expensive, because it requires writing a non-zero value in the "z slot" of the disabled order of that strategy.

An alternative to this entire PR is to change the contract code to update the z value only if the A value is not zero.
But this would make the trade action slightly more expensive **per order**.

It would also bring the strategy to a "singular state" where `y > z`, which should never happen.
There is no practical risk here, because `z` is not used when `A == 0`, and whenever a user creates or updates a strategy, we assert that `y <= z`, but we should nevertheless consider this carefully.