### PR TITLE
handling null block and block number

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bancor/carbon-sdk",
   "type": "module",
   "source": "src/index.ts",
-  "version": "0.0.106-DEV",
+  "version": "0.0.107-DEV",
   "description": "The SDK is a READ-ONLY tool, intended to facilitate working with Carbon contracts. It's a convenient wrapper around our matching algorithm, allowing programs and users get a ready to use transaction data that will allow them to manage strategies and fulfill trades",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/chain-cache/ChainCache.ts
+++ b/src/chain-cache/ChainCache.ts
@@ -85,6 +85,14 @@ export class ChainCache extends (EventEmitter as new () => TypedEventEmitter<Cac
       return;
     }
 
+    // if, due to a bug, the cached latest block number isn't a number, print an error and return
+    if (typeof parsedCache.latestBlockNumber !== 'number') {
+      logger.error(
+        'Cached latest block number is not a number, ignoring cache'
+      );
+      return;
+    }
+
     this._strategiesByPair = Object.entries(
       parsedCache.strategiesByPair
     ).reduce((acc, [key, strategies]) => {
@@ -117,7 +125,13 @@ export class ChainCache extends (EventEmitter as new () => TypedEventEmitter<Cac
     this._latestBlockNumber = parsedCache.latestBlockNumber;
     this._latestTradesByPair = parsedCache.latestTradesByPair;
     this._latestTradesByDirectedPair = parsedCache.latestTradesByDirectedPair;
-    this._blocksMetadata = parsedCache.blocksMetadata;
+
+    // handling a case where, due to a bug, the cached blocks metadata array contains a null item
+    if (parsedCache.blocksMetadata) {
+      this._blocksMetadata = parsedCache.blocksMetadata.filter(
+        (block) => !!block && !!block.number && !!block.hash
+      );
+    }
   }
 
   public serialize(): string {


### PR DESCRIPTION
In some cases, calls to getBlock and getBlockNumber return null. It wasn't handled properly. It was also stored to cache - leading to a reinitialized SDK to fail syncing events.
This fix is handling null values both in chain calls and in cached data.