### PR TITLE
avoid fetching on cache miss

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bancor/carbon-sdk",
   "type": "module",
   "source": "src/index.ts",
-  "version": "0.0.118-DEV",
+  "version": "0.0.119-DEV",
   "description": "The SDK is a READ-ONLY tool, intended to facilitate working with Carbon contracts. It's a convenient wrapper around our matching algorithm, allowing programs and users get a ready to use transaction data that will allow them to manage strategies and fulfill trades",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/chain-cache/index.ts
+++ b/src/chain-cache/index.ts
@@ -43,6 +43,5 @@ export const initSyncedCache = (
     msToWaitBetweenSyncs,
     chunkSize
   );
-  cache.setCacheMissHandler(syncer.syncPairData.bind(syncer));
   return { cache, startDataSync: syncer.startDataSync.bind(syncer) };
 };

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -15,6 +15,7 @@ const originalLog = console.log;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function convertBigNumbersToStrings(obj: any): any {
+  if (obj === undefined || obj === null) return obj;
   if (obj instanceof BigNumber) {
     return obj.toString();
   }

--- a/tests/ChainCache.spec.ts
+++ b/tests/ChainCache.spec.ts
@@ -337,34 +337,4 @@ describe('ChainCache', () => {
       expect(await cache.getTradingFeePPMByPair('xyz', 'abc')).to.equal(13);
     });
   });
-  describe('cache miss', () => {
-    it('getStrategiesByPair call miss handler when pair is not cached', async () => {
-      const cache = new ChainCache();
-      let missHandlerCalled = false;
-      cache.setCacheMissHandler(async (token0, token1) => {
-        missHandlerCalled = true;
-        expect([token0, token1]).to.deep.equal(['abc', 'xyz']);
-      });
-      await cache.getStrategiesByPair('abc', 'xyz');
-      expect(missHandlerCalled).to.be.true;
-    });
-    it('getOrdersByPair call miss handler when pair is not cached', async () => {
-      const cache = new ChainCache();
-      let missHandlerCalled = false;
-      cache.setCacheMissHandler(async (token0, token1) => {
-        missHandlerCalled = true;
-        expect([token0, token1]).to.deep.equal(['abc', 'xyz']);
-      });
-      await cache.getOrdersByPair('abc', 'xyz');
-      expect(missHandlerCalled).to.be.true;
-    });
-    it('getStrategiesByPair calls miss handler, which adds the missing pair, allowing the call to return strategies', async () => {
-      const cache = new ChainCache();
-      cache.setCacheMissHandler(async (token0, token1) => {
-        cache.addPair(token0, token1, [encodedStrategy1]);
-      });
-      const strategies = await cache.getStrategiesByPair('abc', 'xyz');
-      expect(strategies).to.deep.equal([encodedStrategy1]);
-    });
-  });
 });


### PR DESCRIPTION
When cache is asked for a pair that's not cached it was trying to fetch this pair - but if the pair doesn't exist it will just keep trying every time.
There's no real need for this functionality.
Impact is that if the user loads the app in a specific pair in the explorer it will take longer load time as the pair awaits its turn to get fetched - but in any case this entire process was greatly improved.