### PR TITLE
better work on resetting self on reorg

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bancor/carbon-sdk",
   "type": "module",
   "source": "src/index.ts",
-  "version": "0.0.120-DEV",
+  "version": "0.0.121-DEV",
   "description": "The SDK is a READ-ONLY tool, intended to facilitate working with Carbon contracts. It's a convenient wrapper around our matching algorithm, allowing programs and users get a ready to use transaction data that will allow them to manage strategies and fulfill trades",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/chain-cache/ChainCache.ts
+++ b/src/chain-cache/ChainCache.ts
@@ -196,8 +196,7 @@ export class ChainCache extends (EventEmitter as new () => TypedEventEmitter<Cac
     logger.debug('Cache miss for pair', token0, token1, 'resolved');
   }
 
-  public clear(silent: boolean = false): void {
-    const pairs = Object.keys(this._strategiesByPair).map(fromPairKey);
+  public clear(): void {
     this._strategiesByPair = {};
     this._strategiesById = {};
     this._ordersByDirectedPair = {};
@@ -205,9 +204,10 @@ export class ChainCache extends (EventEmitter as new () => TypedEventEmitter<Cac
     this._latestTradesByPair = {};
     this._latestTradesByDirectedPair = {};
     this._blocksMetadata = [];
-    if (!silent) {
-      this.emit('onPairDataChanged', pairs);
-    }
+    this._blocksMetadata = [];
+    this._tradingFeePPMByPair = {};
+    this._isCacheInitialized = false;
+    this.emit('onCacheCleared');
   }
 
   //#region public getters

--- a/src/chain-cache/types.ts
+++ b/src/chain-cache/types.ts
@@ -9,6 +9,7 @@ export type CacheEvents = {
   onPairDataChanged: (affectedPairs: TokenPair[]) => void;
   onPairAddedToCache: (addedPair: TokenPair) => void;
   onCacheInitialized: () => void;
+  onCacheCleared: () => void;
 };
 
 export interface TypedEventEmitter<Events extends EventMap> {


### PR DESCRIPTION
when reorg is detected the chain sync will reset itself, clear cache, emit the new onCacheCleared event and start again to sync data