### PR TITLE
handle too low rate and provide min max prices

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bancor/carbon-sdk",
   "type": "module",
   "source": "src/index.ts",
-  "version": "0.0.121-DEV",
+  "version": "0.0.122-DEV",
   "description": "The SDK is a READ-ONLY tool, intended to facilitate working with Carbon contracts. It's a convenient wrapper around our matching algorithm, allowing programs and users get a ready to use transaction data that will allow them to manage strategies and fulfill trades",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/strategy-management/Toolkit.ts
+++ b/src/strategy-management/Toolkit.ts
@@ -54,6 +54,7 @@ import {
   calculateOverlappingSellBudget,
   decodeStrategy,
   encodeStrategy,
+  getMinMaxPricesByDecimals,
   normalizeRate,
   parseStrategy,
   subtractFee,
@@ -120,6 +121,19 @@ export class Toolkit {
       return decimals;
     };
     this._decimals = new Decimals(fetcher);
+  }
+
+  public async getMinMaxPricesByAddresses(
+    baseToken: string,
+    quoteToken: string
+  ): Promise<{
+    minBuyPrice: string;
+    maxSellPrice: string;
+  }> {
+    const decimals = this._decimals;
+    const baseDecimals = await decimals.fetchDecimals(baseToken);
+    const quoteDecimals = await decimals.fetchDecimals(quoteToken);
+    return getMinMaxPricesByDecimals(baseDecimals, quoteDecimals);
   }
 
   public static getMatchActions(

--- a/src/strategy-management/utils.ts
+++ b/src/strategy-management/utils.ts
@@ -17,6 +17,7 @@ import {
   calculateRequiredLiquidity,
   decodeOrder,
   encodeOrders,
+  lowestPossibleRate,
 } from '../utils/encoders';
 import { Decimals } from '../utils/decimals';
 import { encodedStrategyBNToStr } from '../utils';
@@ -370,6 +371,29 @@ export function enforcePriceRange(
   if (marginalPrice.gte(maxPrice)) return maxPrice;
 
   return marginalPrice;
+}
+
+export function getMinMaxPricesByDecimals(
+  baseTokenDecimals: number,
+  quoteTokenDecimals: number
+): {
+  minBuyPrice: string;
+  maxSellPrice: string;
+} {
+  const minBuyPrice = normalizeRate(
+    lowestPossibleRate.toString(),
+    baseTokenDecimals,
+    quoteTokenDecimals
+  );
+  const maxSellPrice = normalizeInvertedRate(
+    lowestPossibleRate.toString(),
+    quoteTokenDecimals,
+    baseTokenDecimals
+  );
+  return {
+    minBuyPrice,
+    maxSellPrice,
+  };
 }
 
 /**

--- a/src/utils/encoders.ts
+++ b/src/utils/encoders.ts
@@ -17,6 +17,9 @@ export const decodeRate = (value: Decimal) => {
   return value.div(ONE).pow(2);
 };
 
+// The smallest rate that, once encoded, will not be zero.
+export const lowestPossibleRate = decodeRate(new Decimal(1));
+
 export const encodeFloat = (value: BigNumber) => {
   const exponent = bitLength(value.div(ONE));
   const mantissa = value.shr(exponent);
@@ -100,6 +103,14 @@ export const encodeOrder = (
   const L = encodeRate(lowestRate);
   const H = encodeRate(highestRate);
   const M = encodeRate(marginalRate);
+
+  if (L.isZero() && !(H.isZero() && M.isZero())) {
+    throw new Error(
+      `Encoded lowest rate cannot be zero unless the highest and marginal rates are also zero. This may be the result of passing a rate that is zero or too close to zero:\n` +
+        `lowestRate = ${lowestRate}, highestRate = ${highestRate}, marginalRate = ${marginalRate}\n` +
+        `L = ${L}, H = ${H}, M = ${M}`
+    );
+  }
 
   if (
     !(

--- a/tests/encoders.spec.ts
+++ b/tests/encoders.spec.ts
@@ -83,6 +83,22 @@ describe('encoders', () => {
       expect(encodedOrder.B.toString()).to.equal('199032864766430');
     });
 
+    it('should throw an exception when lowest rate is encoded to zero', () => {
+      const order = {
+        liquidity: '100',
+        lowestRate: '0.0000000000000000000000000000001',
+        highestRate: '2',
+        marginalRate: '1',
+      };
+      expect(() => {
+        encodeOrder(order);
+      }).to.throw(
+        `Encoded lowest rate cannot be zero unless the highest and marginal rates are also zero. This may be the result of passing a rate that is zero or too close to zero:\n` +
+          `lowestRate = ${order.lowestRate}, highestRate = ${order.highestRate}, marginalRate = ${order.marginalRate}\n` +
+          `L = 0, H = 398065729532860, M = 281474976710656`
+      );
+    });
+
     it('should throw an exception when high price is higher than mid which is equal to min', () => {
       const order = {
         liquidity: '100',


### PR DESCRIPTION
 - encoders throw exception to prevent creation of orders with B=0 as a result of passing too low rate
 - new methods allow the UI to receive the edge prices allowed given base and quote token decimals