### PR TITLE
Ethers 6 and Simpler init from json

### DIFF
--- a/demos/concentrated-amm-integration/demo.ts
+++ b/demos/concentrated-amm-integration/demo.ts
@@ -29,7 +29,7 @@ async function demonstrateCarbonIntegration() {
   console.log('Starting Carbon integration demo...');
 
   // Initialize provider with proper error handling
-  const provider = new ethers.providers.StaticJsonRpcProvider(PROVIDER_URL);
+  const provider = new ethers.JsonRpcProvider(PROVIDER_URL);
 
   // Initialize Carbon contracts
   const contracts = new Contracts(provider, {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bancor/carbon-sdk",
   "type": "module",
   "source": "src/index.ts",
-  "version": "0.0.126-TEST",
+  "version": "0.0.126-DEV",
   "description": "The SDK is a READ-ONLY tool, intended to facilitate working with Carbon contracts. It's a convenient wrapper around our matching algorithm, allowing programs and users get a ready to use transaction data that will allow them to manage strategies and fulfill trades",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bancor/carbon-sdk",
   "type": "module",
   "source": "src/index.ts",
-  "version": "1.0.0",
+  "version": "0.0.126-TEST",
   "description": "The SDK is a READ-ONLY tool, intended to facilitate working with Carbon contracts. It's a convenient wrapper around our matching algorithm, allowing programs and users get a ready to use transaction data that will allow them to manage strategies and fulfill trades",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
@@ -109,6 +109,7 @@
     "@typescript-eslint/parser": "^8.32.1",
     "chai": "^5.2.0",
     "eslint": "^9.26.0",
+    "ethers": "^6.15.0",
     "mocha": "^11.1.0",
     "rollup": "^4.40.2",
     "rollup-plugin-terser": "^7.0.2",
@@ -120,7 +121,9 @@
   },
   "dependencies": {
     "decimal.js": "^10.5.0",
-    "ethers": "^6.15.0",
     "events": "^3.3.0"
+  },
+  "peerDependencies": {
+    "ethers": "^6.15.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rm -rf dist && rm -rf src/abis/types",
-    "compile-abis": "typechain --target ethers-v5 --out-dir 'src/abis/types' 'src/abis/**/*.json'",
+    "compile-abis": "typechain --target ethers-v6 --out-dir 'src/abis/types' 'src/abis/**/*.json'",
     "prebuild": "yarn clean && yarn compile-abis",
     "build": "yarn lint && rollup -c",
     "test": "yarn lint && mocha",
@@ -100,7 +100,7 @@
     "@rollup/plugin-commonjs": "^28.0.2",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@rollup/plugin-typescript": "^12.1.2",
-    "@typechain/ethers-v5": "^11.1.2",
+    "@typechain/ethers-v6": "^0.5.1",
     "@types/chai": "^5.2.2",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.13.10",
@@ -119,13 +119,8 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@ethersproject/abi": "^5.7.0",
-    "@ethersproject/bignumber": "^5.7.0",
-    "@ethersproject/contracts": "^5.8.0",
-    "@ethersproject/providers": "^5.7.2",
-    "@ethersproject/units": "^5.8.0",
     "decimal.js": "^10.5.0",
-    "ethers": "^5.8.0",
+    "ethers": "^6.15.0",
     "events": "^3.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@bancor/carbon-sdk",
   "type": "module",
   "source": "src/index.ts",
-  "version": "0.0.125-DEV",
+  "version": "1.0.0",
   "description": "The SDK is a READ-ONLY tool, intended to facilitate working with Carbon contracts. It's a convenient wrapper around our matching algorithm, allowing programs and users get a ready to use transaction data that will allow them to manage strategies and fulfill trades",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/adapters/uni-v3/adapter.ts
+++ b/src/adapters/uni-v3/adapter.ts
@@ -1,4 +1,4 @@
-import { BigNumber, Decimal, ONE } from '../../utils/numerics';
+import { Decimal, ONE } from '../../utils/numerics';
 import { EncodedOrder, EncodedStrategy } from '../../common/types';
 import { UniV3CastStrategy, UniV3Pool, UniV3Position } from './types';
 import { decodeFloat, decodeOrder } from '../../utils/encoders';
@@ -27,10 +27,10 @@ function calculateImpliedTick(rate: Decimal, roundUp: boolean): number {
  * @returns {string} The calculated liquidity value
  */
 function calculateLConstant(order: EncodedOrder): string {
-  if (order.A.isZero()) {
+  if (order.A === 0n) {
     return Infinity.toString();
   }
-  return order.z.mul(ONE).div(decodeFloat(order.A)).toString();
+  return ((order.z * ONE) / decodeFloat(order.A)).toString();
 }
 
 function calculateSqrtPriceX96(marginal: Decimal, roundUp: boolean): string {
@@ -86,10 +86,10 @@ function calculatePositionInformation(
 export function castToUniV3(strategy: EncodedStrategy): UniV3CastStrategy {
   // use the token addresses to define which is the base token and which is the quote token. Base token is the token with the lowest address.
 
-  const addr0 = BigNumber.from(strategy.token0);
-  const addr1 = BigNumber.from(strategy.token1);
+  const addr0 = BigInt(strategy.token0);
+  const addr1 = BigInt(strategy.token1);
 
-  const isToken0XAxis = addr0.lt(addr1);
+  const isToken0XAxis = addr0 < addr1;
 
   const pool: UniV3Pool = {
     xAxisToken: isToken0XAxis ? strategy.token0 : strategy.token1,

--- a/src/chain-cache/ChainCache.ts
+++ b/src/chain-cache/ChainCache.ts
@@ -11,14 +11,14 @@ import {
   EncodedOrder,
   EncodedStrategy,
   OrdersMap,
-  RetypeBigNumberToString,
+  RetypeBigIntToString,
   TokenPair,
   TradingFeeUpdate,
   SyncedEvents,
 } from '../common/types';
-import { BigNumberish } from '../utils/numerics';
+import { BigIntish } from '../utils/numerics';
 import {
-  encodedStrategyBNToStr,
+  encodedStrategyBigIntToStr,
   encodedStrategyStrToBN,
 } from '../utils/serializers';
 import { Logger } from '../common/logger';
@@ -33,7 +33,7 @@ type PairToDirectedOrdersMap = { [key: string]: OrdersMap };
 
 type SerializableDump = {
   schemeVersion: number;
-  strategiesByPair: RetypeBigNumberToString<PairToStrategiesMap>;
+  strategiesByPair: RetypeBigIntToString<PairToStrategiesMap>;
   tradingFeePPMByPair: { [key: string]: number };
   latestBlockNumber: number;
 };
@@ -105,10 +105,10 @@ export class ChainCache extends (EventEmitter as new () => TypedEventEmitter<Cac
       schemeVersion,
       strategiesByPair: Object.entries(this._strategiesByPair).reduce(
         (acc, [key, strategies]) => {
-          acc[key] = strategies.map(encodedStrategyBNToStr);
+          acc[key] = strategies.map(encodedStrategyBigIntToStr);
           return acc;
         },
-        {} as RetypeBigNumberToString<PairToStrategiesMap>
+        {} as RetypeBigIntToString<PairToStrategiesMap>
       ),
       tradingFeePPMByPair: this._tradingFeePPMByPair,
       latestBlockNumber: this._latestBlockNumber,
@@ -186,7 +186,7 @@ export class ChainCache extends (EventEmitter as new () => TypedEventEmitter<Cac
     return result;
   }
 
-  public getStrategyById(id: BigNumberish): EncodedStrategy | undefined {
+  public getStrategyById(id: BigIntish): EncodedStrategy | undefined {
     return this._strategiesById[id.toString()];
   }
 
@@ -484,7 +484,7 @@ export class ChainCache extends (EventEmitter as new () => TypedEventEmitter<Cac
     }
     const key = toPairKey(strategy.token0, strategy.token1);
     const strategies = (this._strategiesByPair[key] || []).filter(
-      (s) => !s.id.eq(strategy.id)
+      (s) => s.id !== strategy.id
     );
     strategies.push(strategy);
     this._strategiesByPair[key] = strategies;
@@ -506,7 +506,7 @@ export class ChainCache extends (EventEmitter as new () => TypedEventEmitter<Cac
     const key = toPairKey(strategy.token0, strategy.token1);
     delete this._strategiesById[strategy.id.toString()];
     const strategies = (this._strategiesByPair[key] || []).filter(
-      (s) => !s.id.eq(strategy.id)
+      (s) => s.id !== strategy.id
     );
     this._strategiesByPair[key] = strategies;
     this._removeStrategyOrders(strategy);

--- a/src/chain-cache/README.md
+++ b/src/chain-cache/README.md
@@ -8,6 +8,6 @@ This folder contains the implementation of a blockchain data synchronization sys
 2.  `Fetcher`: The `Fetcher` is an interface of the contracts Reader, which is responsible for fetching data from the blockchain. It contains methods for fetching block numbers, token pairs, trading fees, strategies, and events related to strategies and token trades.
 3.  `ChainCache.ts`: This file defines the `ChainCache` class, which is responsible for managing the local cache of the blockchain data. It contains methods for adding, updating, and deleting data in the cache, as well as methods for querying the cache.
 4.  `utils.ts`: This file contains utility functions that are used by the other classes in this folder. These utility functions include helpers for handling arrays, generating unique keys for token pairs, and other general-purpose functions.
-5.  `types.ts`: This file contains the type definitions for the data structures used in the system, such as `TokenPair`, `EncodedStrategy`, and `TradeData`.
+5.  `types.ts`: This file contains the type definitions for the data structures used in the system, such as `TokenPair`, and `EncodedStrategy`.
 
 To use this system, you need to create instances of the `Fetcher` and `ChainCache` classes and pass them to the constructor of the `ChainSync` class. Then, you can call the `startDataSync()` method of the `ChainSync` instance to start the synchronization process.

--- a/src/chain-cache/utils.ts
+++ b/src/chain-cache/utils.ts
@@ -4,7 +4,7 @@ import { EncodedOrder, TokenPair } from '../common/types';
 const compareTokens = (token0: string, token1: string): number =>
   token0.localeCompare(token1);
 
-const SEPARATOR = '->-<-';
+const SEPARATOR = '_';
 
 // Convert two tokens to a string key
 const toKey = (tokens: string[]): string => {

--- a/src/chain-cache/utils.ts
+++ b/src/chain-cache/utils.ts
@@ -40,5 +40,5 @@ export const toDirectionKey = (token0: string, token1: string): string => {
 };
 
 export function isOrderTradable(order: EncodedOrder): boolean {
-  return order.y.gt(0) && (order.A.gt(0) || order.B.gt(0));
+  return order.y > 0n && (order.A > 0n || order.B > 0n);
 }

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from '../utils/numerics';
 import { getRuntimeConfig } from '../runtime-config';
 
 const verbosity = getRuntimeConfig().logVerbosityLevel;
@@ -7,36 +6,36 @@ function isVerbose(): boolean {
   return verbosity >= 1;
 }
 
-function shouldConvertBigNumbersToStrings(): boolean {
+function shouldConvertBigIntsToStrings(): boolean {
   return verbosity >= 2;
 }
 
 const originalLog = console.log;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function convertBigNumbersToStrings(obj: any): any {
+function convertBigIntsToStrings(obj: any): any {
   if (obj === undefined || obj === null) return obj;
-  if (obj instanceof BigNumber) {
+  if (typeof obj === 'bigint') {
     return obj.toString();
   }
   if (Array.isArray(obj)) {
-    return obj.map(convertBigNumbersToStrings);
+    return obj.map(convertBigIntsToStrings);
   }
   if (typeof obj === 'object') {
     return Object.fromEntries(
       Object.entries(obj).map(([key, value]) => [
         key,
-        convertBigNumbersToStrings(value),
+        convertBigIntsToStrings(value),
       ])
     );
   }
   return obj;
 }
 
-if (shouldConvertBigNumbersToStrings()) {
+if (shouldConvertBigIntsToStrings()) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   console.debug = (...args: any[]) => {
-    const convertedArgs = args.map(convertBigNumbersToStrings);
+    const convertedArgs = args.map(convertBigIntsToStrings);
     originalLog.apply(console, convertedArgs);
   };
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,8 @@
-export { PayableOverrides, PopulatedTransaction } from 'ethers';
-import { BigNumber } from '../utils/numerics';
+import type { TransactionRequest } from 'ethers';
+
+// Type aliases for ethers v6 compatibility
+export type PopulatedTransaction = TransactionRequest;
+export type PayableOverrides = TransactionRequest;
 
 export type RetypeProps<T, From, To> = {
   [K in keyof T]: T[K] extends From
@@ -9,28 +12,28 @@ export type RetypeProps<T, From, To> = {
     : T[K];
 };
 
-export type RetypeBigNumberToString<T> = RetypeProps<T, BigNumber, string>;
+export type RetypeBigIntToString<T> = RetypeProps<T, bigint, string>;
 
 export type Rate = {
-  input: BigNumber;
-  output: BigNumber;
+  input: bigint;
+  output: bigint;
 };
 
-export type RateBNStr = RetypeBigNumberToString<Rate>;
+export type RateBNStr = RetypeBigIntToString<Rate>;
 
 export type Quote = {
-  id: BigNumber;
+  id: bigint;
   rate: Rate;
 };
 
-export type QuoteBNStr = RetypeBigNumberToString<Quote>;
+export type QuoteBNStr = RetypeBigIntToString<Quote>;
 
 export type TradeAction = {
-  strategyId: BigNumber;
-  amount: BigNumber;
+  strategyId: bigint;
+  amount: bigint;
 };
 
-export type TradeActionBNStr = RetypeBigNumberToString<TradeAction>;
+export type TradeActionBNStr = RetypeBigIntToString<TradeAction>;
 
 export type Filter = (rate: Rate) => boolean;
 
@@ -40,29 +43,29 @@ export enum MatchType {
 }
 
 export type MatchAction = {
-  id: BigNumber;
-  input: BigNumber;
-  output: BigNumber;
+  id: bigint;
+  input: bigint;
+  output: bigint;
 };
 
-export type MatchActionBNStr = RetypeBigNumberToString<MatchAction>;
+export type MatchActionBNStr = RetypeBigIntToString<MatchAction>;
 
 export type MatchOptions = {
   [key in MatchType]?: MatchAction[];
 };
 
-export type MatchOptionsBNStr = RetypeBigNumberToString<MatchOptions>;
+export type MatchOptionsBNStr = RetypeBigIntToString<MatchOptions>;
 
 export type TokenPair = [string, string];
 
 export type EncodedOrder = {
-  y: BigNumber;
-  z: BigNumber;
-  A: BigNumber;
-  B: BigNumber;
+  y: bigint;
+  z: bigint;
+  A: bigint;
+  B: bigint;
 };
 
-export type EncodedOrderBNStr = RetypeBigNumberToString<EncodedOrder>;
+export type EncodedOrderBNStr = RetypeBigIntToString<EncodedOrder>;
 
 export type DecodedOrder = {
   liquidity: string;
@@ -75,17 +78,17 @@ export type OrdersMap = {
   [orderId: string]: EncodedOrder;
 };
 
-export type OrdersMapBNStr = RetypeBigNumberToString<OrdersMap>;
+export type OrdersMapBNStr = RetypeBigIntToString<OrdersMap>;
 
 export type EncodedStrategy = {
-  id: BigNumber;
+  id: bigint;
   token0: string;
   token1: string;
   order0: EncodedOrder;
   order1: EncodedOrder;
 };
 
-export type EncodedStrategyBNStr = RetypeBigNumberToString<EncodedStrategy>;
+export type EncodedStrategyBNStr = RetypeBigIntToString<EncodedStrategy>;
 
 export type DecodedStrategy = {
   token0: string;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -94,16 +94,6 @@ export type DecodedStrategy = {
   order1: DecodedOrder;
 };
 
-export type TradeData = {
-  trader: string;
-  sourceToken: string;
-  targetToken: string;
-  sourceAmount: string;
-  targetAmount: string;
-  tradingFeeAmount: string;
-  byTargetAmount: boolean;
-};
-
 export type TradingFeeUpdate = [string, string, number];
 
 export type Action = {
@@ -159,12 +149,6 @@ export type SyncedEvent =
       blockNumber: number;
       logIndex: number;
       data: EncodedStrategy;
-    }
-  | {
-      type: 'TokensTraded';
-      blockNumber: number;
-      logIndex: number;
-      data: TradeData;
     }
   | {
       type: 'TradingFeePPMUpdated';

--- a/src/contracts-api/Contracts.ts
+++ b/src/contracts-api/Contracts.ts
@@ -11,7 +11,7 @@ import {
   CarbonBatcher__factory,
 } from '../abis/types';
 
-import { Provider } from '@ethersproject/providers';
+import { Provider } from 'ethers';
 import { config as defaultConfig } from './config';
 import { ContractsConfig } from './types';
 

--- a/src/contracts-api/ContractsApi.ts
+++ b/src/contracts-api/ContractsApi.ts
@@ -1,4 +1,4 @@
-import { Provider } from '@ethersproject/providers';
+import { Provider } from 'ethers';
 import { ContractsConfig } from './types';
 import Composer from './Composer';
 import { Contracts } from './Contracts';

--- a/src/contracts-api/Reader.ts
+++ b/src/contracts-api/Reader.ts
@@ -1,5 +1,4 @@
-import { BigNumber } from '../utils/numerics';
-import { StrategyStructOutput } from '../abis/types/CarbonController';
+import { StrategyStructOutput, CarbonController } from '../abis/types/CarbonController';
 import { Contracts } from './Contracts';
 import {
   isETHAddress,
@@ -70,7 +69,7 @@ export default class Reader implements Fetcher {
     return this._multicallService.execute(calls, blockHeight);
   }
 
-  public async strategy(id: BigNumber): Promise<EncodedStrategy> {
+  public async strategy(id: bigint): Promise<EncodedStrategy> {
     logger.debug('strategy called', id);
     try {
       const res = await this._contracts.carbonController.strategy(id);
@@ -81,12 +80,12 @@ export default class Reader implements Fetcher {
     }
   }
 
-  public async strategies(ids: BigNumber[]): Promise<EncodedStrategy[]> {
+  public async strategies(ids: bigint[]): Promise<EncodedStrategy[]> {
     logger.debug('strategies called', ids);
     try {
       const results = await this._multicall(
         ids.map((id) => ({
-          contractAddress: this._contracts.carbonController.address,
+          contractAddress: this._contracts.carbonController.target as string,
           interface: this._contracts.carbonController.interface,
           methodName: 'strategy',
           methodParameters: [id],
@@ -165,7 +164,7 @@ export default class Reader implements Fetcher {
         // First, get the first chunk for all pairs using multicall
         const firstChunkResults = await this._multicall(
           pairs.map((pair) => ({
-            contractAddress: this._contracts.carbonController.address,
+            contractAddress: this._contracts.carbonController.target as string,
             interface: this._contracts.carbonController.interface,
             methodName: 'strategiesByPair',
             methodParameters: [pair[0], pair[1], 0, chunkSize],
@@ -244,10 +243,11 @@ export default class Reader implements Fetcher {
     }
   }
 
-  public tradingFeePPM(): Promise<number> {
+  public async tradingFeePPM(): Promise<number> {
     logger.debug('tradingFeePPM called');
     try {
-      return this._contracts.carbonController.tradingFeePPM();
+      const result = await this._contracts.carbonController.tradingFeePPM();
+      return Number(result);
     } catch (error) {
       logger.error('tradingFeePPM error', error);
       throw error;
@@ -256,20 +256,21 @@ export default class Reader implements Fetcher {
 
   public onTradingFeePPMUpdated(
     listener: (prevFeePPM: number, newFeePPM: number) => void
-  ) {
+  ): Promise<CarbonController> {
     return this._contracts.carbonController.on(
-      'TradingFeePPMUpdated',
-      function (prevFeePPM: number, newFeePPM: number) {
-        logger.debug('TradingFeePPMUpdated fired with', arguments);
-        listener(prevFeePPM, newFeePPM);
+      this._contracts.carbonController.getEvent('TradingFeePPMUpdated'),
+      (prevFeePPM: bigint, newFeePPM: bigint, _event) => {
+        logger.debug('TradingFeePPMUpdated fired with', { prevFeePPM, newFeePPM });
+        listener(Number(prevFeePPM), Number(newFeePPM));
       }
     );
   }
 
-  public pairTradingFeePPM(token0: string, token1: string): Promise<number> {
+  public async pairTradingFeePPM(token0: string, token1: string): Promise<number> {
     logger.debug('pairTradingFeePPM called', token0, token1);
     try {
-      return this._contracts.carbonController.pairTradingFeePPM(token0, token1);
+      const result = await this._contracts.carbonController.pairTradingFeePPM(token0, token1);
+      return Number(result);
     } catch (error) {
       logger.error('pairTradingFeePPM error', error);
       throw error;
@@ -283,7 +284,7 @@ export default class Reader implements Fetcher {
     try {
       const results = await this._multicall(
         pairs.map((pair) => ({
-          contractAddress: this._contracts.carbonController.address,
+          contractAddress: this._contracts.carbonController.target as string,
           interface: this._contracts.carbonController.interface,
           methodName: 'pairTradingFeePPM',
           methodParameters: [pair[0], pair[1]],
@@ -309,24 +310,20 @@ export default class Reader implements Fetcher {
     ) => void
   ) {
     return this._contracts.carbonController.on(
-      'PairTradingFeePPMUpdated',
-      function (
-        token0: string,
-        token1: string,
-        prevFeePPM: number,
-        newFeePPM: number
-      ) {
-        logger.debug('PairTradingFeePPMUpdated fired with', arguments);
-        listener(token0, token1, prevFeePPM, newFeePPM);
+      this._contracts.carbonController.getEvent('PairTradingFeePPMUpdated'),
+      (token0: string, token1: string, prevFeePPM: bigint, newFeePPM: bigint, _event) => {
+        logger.debug('PairTradingFeePPMUpdated fired with', { token0, token1, prevFeePPM, newFeePPM });
+        listener(token0, token1, Number(prevFeePPM), Number(newFeePPM));
       }
     );
   }
 
-  public getDecimalsByAddress = async (address: string) => {
+  public getDecimalsByAddress = async (address: string): Promise<number> => {
     if (isETHAddress(address)) {
-      return 18 as number;
+      return 18;
     }
-    return this._contracts.token(address).decimals();
+    const result = await this._contracts.token(address).decimals();
+    return Number(result);
   };
 
   public getBlockNumber = async (): Promise<number> => {
@@ -334,7 +331,14 @@ export default class Reader implements Fetcher {
   };
 
   public getBlock = async (blockNumber: number): Promise<BlockMetadata> => {
-    return this._contracts.provider.getBlock(blockNumber);
+    const block = await this._contracts.provider.getBlock(blockNumber);
+    if (!block) {
+      throw new Error(`Block ${blockNumber} not found`);
+    }
+    return {
+      number: block.number,
+      hash: block.hash ?? '',
+    };
   };
 
   /**
@@ -364,7 +368,7 @@ export default class Reader implements Fetcher {
     const chunkResults = await Promise.all(
       chunks.map(async ({ start, end }) => {
         const logs = await this._contracts.provider.getLogs({
-          address: this._contracts.carbonController.address,
+          address: this._contracts.carbonController.target as string,
           fromBlock: start,
           toBlock: end,
         });
@@ -410,7 +414,7 @@ export default class Reader implements Fetcher {
             return {
               type: eventType,
               blockNumber: log.blockNumber,
-              logIndex: log.logIndex,
+              logIndex: log.index,
               data: eventData,
             } as const;
           }
@@ -419,7 +423,7 @@ export default class Reader implements Fetcher {
             return {
               type: eventType,
               blockNumber: log.blockNumber,
-              logIndex: log.logIndex,
+              logIndex: log.index,
               data: eventData,
             } as const;
           }
@@ -432,7 +436,7 @@ export default class Reader implements Fetcher {
             return {
               type: eventType,
               blockNumber: log.blockNumber,
-              logIndex: log.logIndex,
+              logIndex: log.index,
               data: eventData,
             } as const;
           }

--- a/src/contracts-api/Reader.ts
+++ b/src/contracts-api/Reader.ts
@@ -13,7 +13,6 @@ import {
   Fetcher,
   TokenPair,
   BlockMetadata,
-  TradeData,
   TradingFeeUpdate,
   SyncedEvents,
   SyncedEvent,
@@ -407,23 +406,6 @@ export default class Reader implements Fetcher {
                 y: parsedLog.args.order1.y,
                 z: parsedLog.args.order1.z,
               },
-            };
-            return {
-              type: eventType,
-              blockNumber: log.blockNumber,
-              logIndex: log.logIndex,
-              data: eventData,
-            } as const;
-          }
-          case 'TokensTraded': {
-            const eventData: TradeData = {
-              trader: parsedLog.args.trader,
-              sourceToken: parsedLog.args.sourceToken,
-              targetToken: parsedLog.args.targetToken,
-              sourceAmount: parsedLog.args.sourceAmount.toString(),
-              targetAmount: parsedLog.args.targetAmount.toString(),
-              tradingFeeAmount: parsedLog.args.tradingFeeAmount.toString(),
-              byTargetAmount: parsedLog.args.byTargetAmount,
             };
             return {
               type: eventType,

--- a/src/contracts-api/utils.ts
+++ b/src/contracts-api/utils.ts
@@ -1,6 +1,6 @@
-import { BigNumber, BigNumberish } from '../utils/numerics';
-import { PayableOverrides } from 'ethers';
-import { Interface } from '@ethersproject/abi';
+import { BigIntish } from '../utils/numerics';
+import { PayableOverrides } from '../common/types';
+import { Interface } from 'ethers';
 import { Multicall } from '../abis/types';
 import { TradeAction } from '../common/types';
 
@@ -67,7 +67,7 @@ export const multicall = async (
   return service.execute(calls, blockHeight);
 };
 
-export const isETHAddress = (address: string) => {
+export const isETHAddress = (address: string): boolean => {
   return address.toLowerCase() === ETH_ADDRESS;
 };
 
@@ -75,18 +75,19 @@ export const buildTradeOverrides = (
   sourceToken: string,
   tradeActions: TradeAction[],
   byTarget: boolean,
-  maxInput: BigNumberish,
+  maxInput: BigIntish,
   overrides?: PayableOverrides
 ): PayableOverrides => {
   const customOverrides = { ...overrides };
   if (isETHAddress(sourceToken)) {
     if (byTarget) {
-      customOverrides.value = BigNumber.from(maxInput);
+      customOverrides.value = BigInt(maxInput);
     } else {
-      customOverrides.value = tradeActions.reduce(
-        (acc, cur) => acc.add(cur.amount as BigNumberish),
-        BigNumber.from(0)
+      const total = tradeActions.reduce(
+        (acc, cur) => acc + cur.amount,
+        0n
       );
+      customOverrides.value = total;
     }
   }
   return customOverrides;

--- a/src/strategy-management/utils.ts
+++ b/src/strategy-management/utils.ts
@@ -1,6 +1,5 @@
 import {
-  BigNumber,
-  BigNumberish,
+  BigIntish,
   Decimal,
   formatUnits,
   parseUnits,
@@ -20,12 +19,12 @@ import {
   lowestPossibleRate,
 } from '../utils/encoders';
 import { Decimals } from '../utils/decimals';
-import { encodedStrategyBNToStr } from '../utils';
+import { encodedStrategyBigIntToStr } from '../utils';
 
 const logger = new Logger('utils.ts');
 
 export function normalizeRate(
-  amount: BigNumberish,
+  amount: BigIntish,
   amountTokenDecimals: number,
   otherTokenDecimals: number
 ) {
@@ -35,7 +34,7 @@ export function normalizeRate(
 }
 
 export function normalizeInvertedRate(
-  amount: BigNumberish,
+  amount: BigIntish,
   amountTokenDecimals: number,
   otherTokenDecimals: number
 ) {
@@ -61,7 +60,7 @@ export const encodeStrategy = (
 
 export const decodeStrategy = (
   strategy: EncodedStrategy
-): DecodedStrategy & { id: BigNumber; encoded: EncodedStrategy } => {
+): DecodedStrategy & { id: bigint; encoded: EncodedStrategy } => {
   return {
     id: strategy.id,
     token0: strategy.token0,
@@ -80,7 +79,7 @@ export const decodeStrategy = (
  * @throws {Error} If an error occurs while fetching the decimals for the tokens.
  */
 export async function parseStrategy(
-  strategy: DecodedStrategy & { id: BigNumber; encoded: EncodedStrategy },
+  strategy: DecodedStrategy & { id: bigint; encoded: EncodedStrategy },
   decimals: Decimals
 ): Promise<Strategy> {
   logger.debug('parseStrategy called', arguments);
@@ -113,7 +112,7 @@ export async function parseStrategy(
   const buyBudget = formatUnits(order1.liquidity, decimals1);
 
   const strId = id.toString();
-  const strEncoded = encodedStrategyBNToStr(encoded);
+  const strEncoded = encodedStrategyBigIntToStr(encoded);
   logger.debug('parseStrategy info:', {
     id: strId,
     token0,
@@ -344,17 +343,14 @@ export function createOrders(
 
 export const PPM_RESOLUTION = 1_000_000;
 
-export function addFee(amount: BigNumberish, tradingFeePPM: number): Decimal {
+export function addFee(amount: BigIntish, tradingFeePPM: number): Decimal {
   return new Decimal(amount.toString())
     .mul(PPM_RESOLUTION)
     .div(PPM_RESOLUTION - tradingFeePPM)
     .ceil();
 }
 
-export function subtractFee(
-  amount: BigNumberish,
-  tradingFeePPM: number
-): Decimal {
+export function subtractFee(amount: BigIntish, tradingFeePPM: number): Decimal {
   return new Decimal(amount.toString())
     .mul(PPM_RESOLUTION - tradingFeePPM)
     .div(PPM_RESOLUTION)

--- a/src/trade-matcher/utils.ts
+++ b/src/trade-matcher/utils.ts
@@ -1,13 +1,13 @@
 import { Rate } from '../common/types';
 
 export const sortByMinRate = (x: Rate, y: Rate): number => {
-  const lhs = x.output.mul(y.input);
-  const rhs = y.output.mul(x.input);
-  const lt = lhs.lt(rhs);
-  const gt = lhs.gt(rhs);
+  const lhs = x.output * y.input;
+  const rhs = y.output * x.input;
+  const lt = lhs < rhs;
+  const gt = lhs > rhs;
   const eq = !lt && !gt;
-  const is_lt = lt || (eq && x.output.lt(y.output));
-  const is_gt = gt || (eq && x.output.gt(y.output));
+  const is_lt = lt || (eq && x.output < y.output);
+  const is_gt = gt || (eq && x.output > y.output);
   return +is_lt - +is_gt;
 };
 

--- a/src/utils/encoders.ts
+++ b/src/utils/encoders.ts
@@ -29,7 +29,7 @@ export const encodeFloat = (value: bigint): bigint => {
 };
 
 export const decodeFloat = (value: bigint): bigint => {
-  return (value % ONE) << BigInt(Number(value / ONE));
+  return value % ONE << BigInt(Number(value / ONE));
 };
 
 export const encodeOrders = ([order0, order1]: [DecodedOrder, DecodedOrder]): [
@@ -92,10 +92,7 @@ export const areScaledRatesEqual = (x: string, y: string): boolean => {
   return xScaled === yScaled;
 };
 
-export const encodeOrder = (
-  order: DecodedOrder,
-  z?: bigint
-): EncodedOrder => {
+export const encodeOrder = (order: DecodedOrder, z?: bigint): EncodedOrder => {
   const liquidity = new Decimal(order.liquidity);
   const lowestRate = new Decimal(order.lowestRate);
   const highestRate = new Decimal(order.highestRate);
@@ -114,15 +111,11 @@ export const encodeOrder = (
     );
   }
 
-  const HDec = BnToDec(H);
-  const MDec = BnToDec(M);
-  const LDec = BnToDec(L);
-
   if (
     !(
-      (HDec.gte(MDec) && MDec.gt(LDec)) ||
-      (HDec.eq(MDec) && MDec.eq(LDec)) ||
-      (HDec.gt(MDec) && MDec.eq(LDec) && y === 0n)
+      (H >= M && M > L) ||
+      (H === M && M === L) ||
+      (H > M && M === L && y === 0n)
     )
   )
     throw new Error(
@@ -135,12 +128,7 @@ export const encodeOrder = (
 
   return {
     y,
-    z:
-      z !== undefined
-        ? z
-        : H === M || y === 0n
-        ? y
-        : (y * (H - L)) / (M - L),
+    z: z !== undefined ? z : H === M || y === 0n ? y : (y * (H - L)) / (M - L),
     A: encodeFloat(H - L),
     B: encodeFloat(L),
   };

--- a/src/utils/numerics.ts
+++ b/src/utils/numerics.ts
@@ -1,8 +1,4 @@
-import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
-import {
-  parseUnits as _parseUnits,
-  formatUnits as _formatUnits,
-} from '@ethersproject/units';
+import { parseUnits as _parseUnits, formatUnits as _formatUnits } from 'ethers';
 import DecimalJS from 'decimal.js';
 
 const Decimal = DecimalJS.clone();
@@ -13,35 +9,37 @@ Decimal.set({
   toExpPos: 300,
 });
 
-export { Decimal, BigNumber, BigNumberish };
+export type BigIntish = string | number | bigint;
+
+export { Decimal };
 export type Decimal = DecimalJS;
 
-export const BigNumberMin = (a: BigNumberish, b: BigNumberish) => {
-  const aBN = BigNumber.from(a);
-  const bBN = BigNumber.from(b);
-  return aBN.lt(bBN) ? aBN : bBN;
+export const BigNumberMin = (a: BigIntish, b: BigIntish): bigint => {
+  const aBN = BigInt(a);
+  const bBN = BigInt(b);
+  return aBN < bBN ? aBN : bBN;
 };
 
-export const BigNumberMax = (a: BigNumberish, b: BigNumberish) => {
-  const aBN = BigNumber.from(a);
-  const bBN = BigNumber.from(b);
-  return aBN.gt(bBN) ? aBN : bBN;
+export const BigNumberMax = (a: BigIntish, b: BigIntish): bigint => {
+  const aBN = BigInt(a);
+  const bBN = BigInt(b);
+  return aBN > bBN ? aBN : bBN;
 };
 
-export const ONE = 2 ** 48;
+export const ONE = 2n ** 48n;
 export const TEN = new Decimal(10);
-export const MAX_UINT256 = BigNumber.from(2).pow(256).sub(1);
+export const MAX_UINT256 = 2n ** 256n - 1n;
 
 export const tenPow = (dec0: number, dec1: number) => {
   const diff = dec0 - dec1;
   return TEN.pow(diff);
 };
 
-export const BnToDec = (x: BigNumber) => new Decimal(x.toString());
-export const DecToBn = (x: Decimal) => BigNumber.from(x.toFixed());
+export const BnToDec = (x: bigint): Decimal => new Decimal(x.toString());
+export const DecToBn = (x: Decimal): bigint => BigInt(x.toFixed());
 
-export const mulDiv = (x: BigNumber, y: BigNumber, z: BigNumber) =>
-  y.eq(z) ? x : x.mul(y).div(z);
+export const mulDiv = (x: bigint, y: bigint, z: bigint): bigint =>
+  y === z ? x : (x * y) / z;
 
 export function trimDecimal(input: string, precision: number): string {
   // Use Decimal for precise arithmetic
@@ -52,13 +50,14 @@ export function trimDecimal(input: string, precision: number): string {
 }
 
 // A take on parseUnits that supports floating point
-export function parseUnits(amount: string, decimals: number): BigNumber {
+export function parseUnits(amount: string, decimals: number): bigint {
   const trimmed = trimDecimal(amount, decimals);
   return _parseUnits(trimmed, decimals);
 }
 
-export function formatUnits(amount: BigNumberish, decimals: number): string {
-  const res = _formatUnits(amount, decimals);
+export function formatUnits(amount: BigIntish, decimals: number): string {
+  const amountBN = BigInt(amount);
+  const res = _formatUnits(amountBN, decimals);
 
   // remove trailing 000
   return new Decimal(res).toFixed();

--- a/src/utils/serializers.ts
+++ b/src/utils/serializers.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from './numerics';
 import {
   EncodedOrder,
   EncodedOrderBNStr,
@@ -8,17 +7,17 @@ import {
   MatchActionBNStr,
   OrdersMap,
   OrdersMapBNStr,
-  RetypeBigNumberToString,
+  RetypeBigIntToString,
   TradeAction,
   TradeActionBNStr,
 } from '../common/types';
 
-export const replaceBigNumbersWithStrings = <T>(
+export const replaceBigIntsWithStrings = <T>(
   obj: T
-): RetypeBigNumberToString<T> => {
+): RetypeBigIntToString<T> => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function replace(obj: any): any {
-    if (BigNumber.isBigNumber(obj)) {
+    if (typeof obj === 'bigint') {
       return obj.toString();
     }
 
@@ -34,29 +33,29 @@ export const replaceBigNumbersWithStrings = <T>(
     return obj;
   }
 
-  return replace(obj) as RetypeBigNumberToString<T>;
+  return replace(obj) as RetypeBigIntToString<T>;
 };
 
 export const encodedOrderStrToBN = (order: EncodedOrderBNStr): EncodedOrder => {
   return {
-    y: BigNumber.from(order.y),
-    z: BigNumber.from(order.z),
-    A: BigNumber.from(order.A),
-    B: BigNumber.from(order.B),
+    y: BigInt(order.y),
+    z: BigInt(order.z),
+    A: BigInt(order.A),
+    B: BigInt(order.B),
   };
 };
 
-export const encodedStrategyBNToStr = (
+export const encodedStrategyBigIntToStr = (
   strategy: EncodedStrategy
 ): EncodedStrategyBNStr => {
-  return replaceBigNumbersWithStrings(strategy);
+  return replaceBigIntsWithStrings(strategy);
 };
 
 export const encodedStrategyStrToBN = (
   strategy: EncodedStrategyBNStr
 ): EncodedStrategy => {
   return {
-    id: BigNumber.from(strategy.id),
+    id: BigInt(strategy.id),
     token0: strategy.token0,
     token1: strategy.token1,
     order0: encodedOrderStrToBN(strategy.order0),
@@ -65,7 +64,7 @@ export const encodedStrategyStrToBN = (
 };
 
 export const ordersMapBNToStr = (ordersMap: OrdersMap): OrdersMapBNStr => {
-  return replaceBigNumbersWithStrings(ordersMap);
+  return replaceBigIntsWithStrings(ordersMap);
 };
 
 export const ordersMapStrToBN = (ordersMap: OrdersMapBNStr): OrdersMap => {
@@ -77,12 +76,12 @@ export const ordersMapStrToBN = (ordersMap: OrdersMapBNStr): OrdersMap => {
 };
 
 export const matchActionBNToStr = (action: MatchAction): MatchActionBNStr => {
-  return replaceBigNumbersWithStrings(action);
+  return replaceBigIntsWithStrings(action);
 };
 
 export const tradeActionStrToBN = (action: TradeActionBNStr): TradeAction => {
   return {
-    strategyId: BigNumber.from(action.strategyId),
-    amount: BigNumber.from(action.amount),
+    strategyId: BigInt(action.strategyId),
+    amount: BigInt(action.amount),
   };
 };

--- a/src/utils/serializers.ts
+++ b/src/utils/serializers.ts
@@ -37,10 +37,6 @@ export const replaceBigNumbersWithStrings = <T>(
   return replace(obj) as RetypeBigNumberToString<T>;
 };
 
-export const encodedOrderBNToStr = (order: EncodedOrder): EncodedOrderBNStr => {
-  return replaceBigNumbersWithStrings(order);
-};
-
 export const encodedOrderStrToBN = (order: EncodedOrderBNStr): EncodedOrder => {
   return {
     y: BigNumber.from(order.y),

--- a/tests/ChainCache.spec.ts
+++ b/tests/ChainCache.spec.ts
@@ -6,24 +6,22 @@ import {
   TokenPair,
   TradingFeeUpdate,
 } from '../src/common/types';
-import { BigNumber } from '../src/utils/numerics';
-
 const encodedOrder1: EncodedOrder = {
-  y: BigNumber.from(1),
-  z: BigNumber.from(2),
-  A: BigNumber.from(3),
-  B: BigNumber.from(4),
+  y: 1n,
+  z: 2n,
+  A: 3n,
+  B: 4n,
 };
 
 const encodedOrder2: EncodedOrder = {
-  y: BigNumber.from(5),
-  z: BigNumber.from(6),
-  A: BigNumber.from(7),
-  B: BigNumber.from(8),
+  y: 5n,
+  z: 6n,
+  A: 7n,
+  B: 8n,
 };
 
 const encodedStrategy1: EncodedStrategy = {
-  id: BigNumber.from(1),
+  id: 1n,
   token0: 'abc',
   token1: 'xyz',
   order0: encodedOrder1,
@@ -31,7 +29,7 @@ const encodedStrategy1: EncodedStrategy = {
 };
 
 const encodedStrategy2: EncodedStrategy = {
-  id: BigNumber.from(2),
+  id: 2n,
   token0: 'xyz',
   token1: 'abc',
   order0: encodedOrder2,
@@ -198,7 +196,7 @@ describe('ChainCache', () => {
       const cache = new ChainCache();
       const encodedStrategy1_mod = {
         ...encodedStrategy1,
-        id: BigNumber.from(encodedStrategy1.id.toString()),
+        id: BigInt(encodedStrategy1.id.toString()),
       };
       cache.addPair('abc', 'xyz', [encodedStrategy1]);
       cache.applyEvents(
@@ -219,7 +217,7 @@ describe('ChainCache', () => {
       const cache = new ChainCache();
       const encodedStrategy1_mod = {
         ...encodedStrategy1,
-        id: BigNumber.from(encodedStrategy1.id.toString()),
+        id: BigInt(encodedStrategy1.id.toString()),
       };
       cache.addPair('abc', 'xyz', [encodedStrategy1]);
       cache.applyEvents(

--- a/tests/ChainSync.spec.ts
+++ b/tests/ChainSync.spec.ts
@@ -3,12 +3,7 @@ import sinon from 'sinon';
 import { ChainSync } from '../src/chain-cache/ChainSync';
 import { ChainCache } from '../src/chain-cache/ChainCache';
 import { BigNumber } from '../src/utils/numerics';
-import {
-  EncodedStrategy,
-  Fetcher,
-  TokenPair,
-  TradeData,
-} from '../src/common/types';
+import { EncodedStrategy, Fetcher, TokenPair } from '../src/common/types';
 
 describe('ChainSync', () => {
   let chainSync: ChainSync;
@@ -31,16 +26,6 @@ describe('ChainSync', () => {
       A: BigNumber.from(700),
       B: BigNumber.from(800),
     },
-  };
-
-  const mockTradeData: TradeData = {
-    trader: '0x789',
-    sourceToken: '0x123',
-    targetToken: '0x456',
-    sourceAmount: '1000',
-    targetAmount: '2000',
-    tradingFeeAmount: '10',
-    byTargetAmount: true,
   };
 
   beforeEach(() => {
@@ -179,30 +164,6 @@ describe('ChainSync', () => {
       expect(strategies).to.have.length(0);
     });
 
-    it('should process TokensTraded events correctly', async () => {
-      mockFetcher.getEvents = async () => [
-        {
-          type: 'TokensTraded',
-          blockNumber: chainCache.getLatestBlockNumber() + 1,
-          logIndex: 0,
-          data: mockTradeData,
-        },
-      ];
-
-      await chainSync.startDataSync();
-
-      // wait until chainCache emits onPairDataChanged
-      await new Promise((resolve) => {
-        chainCache.on('onPairDataChanged', resolve);
-      });
-
-      const trade = await chainCache.getLatestTradeByPair(
-        mockTradeData.targetToken,
-        mockTradeData.sourceToken
-      );
-      expect(trade).to.deep.equal(mockTradeData);
-    });
-
     it('should process TradingFeePPMUpdated events correctly', async () => {
       mockFetcher.getEvents = async () => [
         {
@@ -213,10 +174,10 @@ describe('ChainSync', () => {
         },
         // this is just to have the event to emit onPairDataChanged
         {
-          type: 'TokensTraded',
+          type: 'StrategyCreated',
           blockNumber: chainCache.getLatestBlockNumber() + 1,
           logIndex: 1,
-          data: mockTradeData,
+          data: mockEncodedStrategy,
         },
       ];
 
@@ -247,10 +208,10 @@ describe('ChainSync', () => {
         },
         // this is just to have the event to emit onPairDataChanged
         {
-          type: 'TokensTraded',
+          type: 'StrategyCreated',
           blockNumber: chainCache.getLatestBlockNumber() + 1,
           logIndex: 1,
-          data: mockTradeData,
+          data: mockEncodedStrategy,
         },
       ];
 

--- a/tests/ChainSync.spec.ts
+++ b/tests/ChainSync.spec.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { ChainSync } from '../src/chain-cache/ChainSync';
 import { ChainCache } from '../src/chain-cache/ChainCache';
-import { BigNumber } from '../src/utils/numerics';
 import { EncodedStrategy, Fetcher, TokenPair } from '../src/common/types';
 
 describe('ChainSync', () => {
@@ -11,20 +10,20 @@ describe('ChainSync', () => {
   let mockFetcher: Fetcher;
 
   const mockEncodedStrategy: EncodedStrategy = {
-    id: BigNumber.from(1),
+    id: 1n,
     token0: '0x123',
     token1: '0x456',
     order0: {
-      y: BigNumber.from(100),
-      z: BigNumber.from(200),
-      A: BigNumber.from(300),
-      B: BigNumber.from(400),
+      y: 100n,
+      z: 200n,
+      A: 300n,
+      B: 400n,
     },
     order1: {
-      y: BigNumber.from(500),
-      z: BigNumber.from(600),
-      A: BigNumber.from(700),
-      B: BigNumber.from(800),
+      y: 500n,
+      z: 600n,
+      A: 700n,
+      B: 800n,
     },
   };
 
@@ -46,15 +45,15 @@ describe('ChainSync', () => {
         ['0x123', '0x456'],
       ],
       strategiesByPair: async (_token0: string, _token1: string) => [
-        { ...mockEncodedStrategy, id: BigNumber.from(2) },
-        { ...mockEncodedStrategy, id: BigNumber.from(3) },
+        { ...mockEncodedStrategy, id: 2n },
+        { ...mockEncodedStrategy, id: 3n },
       ],
       strategiesByPairs: async (_pairs: TokenPair[]) => [
         {
           pair: ['0x123', '0x456'],
           strategies: [
-            { ...mockEncodedStrategy, id: BigNumber.from(2) },
-            { ...mockEncodedStrategy, id: BigNumber.from(3) },
+            { ...mockEncodedStrategy, id: 2n },
+            { ...mockEncodedStrategy, id: 3n },
           ],
         },
       ],
@@ -100,10 +99,10 @@ describe('ChainSync', () => {
 
       const updatedStrategy = {
         ...mockEncodedStrategy,
-        id: BigNumber.from(2),
+        id: 2n,
         order0: {
           ...mockEncodedStrategy.order0,
-          y: BigNumber.from(150),
+          y: 150n,
         },
       };
       // Then update the second strategy
@@ -141,13 +140,13 @@ describe('ChainSync', () => {
           type: 'StrategyDeleted',
           blockNumber: chainCache.getLatestBlockNumber() + 1,
           logIndex: 0,
-          data: { ...mockEncodedStrategy, id: BigNumber.from(2) },
+          data: { ...mockEncodedStrategy, id: 2n },
         },
         {
           type: 'StrategyDeleted',
           blockNumber: chainCache.getLatestBlockNumber() + 1,
           logIndex: 1,
-          data: { ...mockEncodedStrategy, id: BigNumber.from(3) },
+          data: { ...mockEncodedStrategy, id: 3n },
         },
       ];
 
@@ -238,10 +237,10 @@ describe('ChainSync', () => {
           logIndex: 0,
           data: {
             ...mockEncodedStrategy,
-            id: BigNumber.from(2),
+            id: 2n,
             order0: {
               ...mockEncodedStrategy.order0,
-              y: BigNumber.from(150),
+              y: 150n,
             },
           },
         },
@@ -251,10 +250,10 @@ describe('ChainSync', () => {
           logIndex: 1,
           data: {
             ...mockEncodedStrategy,
-            id: BigNumber.from(2),
+            id: 2n,
             order0: {
               ...mockEncodedStrategy.order0,
-              y: BigNumber.from(200),
+              y: 200n,
             },
           },
         },

--- a/tests/adapters.uni-v3.spec.ts
+++ b/tests/adapters.uni-v3.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { BigNumber } from '../src/utils/numerics';
 import {
   castToUniV3,
   batchCastToUniV3,
@@ -439,20 +438,20 @@ describe('Uniswap V3 Adapter', () => {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const strategyFromDemoStrategy = (strategy: any): EncodedStrategy => ({
-    id: BigNumber.from(strategy.id),
+    id: BigInt(strategy.id),
     token0: strategy.token0,
     token1: strategy.token1,
     order0: {
-      y: BigNumber.from(strategy.order0.y),
-      z: BigNumber.from(strategy.order0.z),
-      A: BigNumber.from(strategy.order0.A),
-      B: BigNumber.from(strategy.order0.B),
+      y: BigInt(strategy.order0.y),
+      z: BigInt(strategy.order0.z),
+      A: BigInt(strategy.order0.A),
+      B: BigInt(strategy.order0.B),
     },
     order1: {
-      y: BigNumber.from(strategy.order1.y),
-      z: BigNumber.from(strategy.order1.z),
-      A: BigNumber.from(strategy.order1.A),
-      B: BigNumber.from(strategy.order1.B),
+      y: BigInt(strategy.order1.y),
+      z: BigInt(strategy.order1.z),
+      A: BigInt(strategy.order1.A),
+      B: BigInt(strategy.order1.B),
     },
   });
 
@@ -531,30 +530,30 @@ describe('Uniswap V3 Adapter', () => {
           );
         }
         // check that token0 is the xAxisToken only if the address is lower than token1
-        const addr0 = BigNumber.from(strategy.token0);
-        const addr1 = BigNumber.from(strategy.token1);
-        const isToken0XAxis = addr0.lt(addr1);
+        const addr0 = BigInt(strategy.token0);
+        const addr1 = BigInt(strategy.token1);
+        const isToken0XAxis = addr0 < addr1;
         expect(uniV3Strategy.pool.xAxisToken).to.equal(
           isToken0XAxis ? strategy.token0 : strategy.token1
         );
 
         // check that if order0.A is 0 then the liquidity is Infinity in the sell order and if order1.A is 0 then the liquidity is Infinity in the buy order
-        if (strategy.order0.A.eq(0)) {
+        if (strategy.order0.A === 0n) {
           expect(uniV3Strategy.sellOrder.liquidity).to.equal(
             Infinity.toString()
           );
         }
-        if (strategy.order1.A.eq(0)) {
+        if (strategy.order1.A === 0n) {
           expect(uniV3Strategy.buyOrder.liquidity).to.equal(
             Infinity.toString()
           );
         }
 
         // check that if order0.z is 0 then the liquidity is 0 in the sell order and if order1.z is 0 then the liquidity is 0 in the buy order
-        if (strategy.order0.z.eq(0)) {
+        if (strategy.order0.z === 0n) {
           expect(uniV3Strategy.sellOrder.liquidity).to.equal('0');
         }
-        if (strategy.order1.z.eq(0)) {
+        if (strategy.order1.z === 0n) {
           expect(uniV3Strategy.buyOrder.liquidity).to.equal('0');
         }
       });

--- a/tests/cache-utils.spec.ts
+++ b/tests/cache-utils.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { toPairKey, toDirectionKey } from '../src/chain-cache/utils';
 
-const SEPARATOR = '->-<-';
+const SEPARATOR = '_';
 describe('toPairKey', () => {
   it('should return the key for two tokens sorted in alphabetical order', () => {
     expect(toPairKey('abc', 'xyz')).to.equal(`abc${SEPARATOR}xyz`);

--- a/tests/chain-utils.spec.ts
+++ b/tests/chain-utils.spec.ts
@@ -1,4 +1,4 @@
-import { BigNumber, PayableOverrides } from 'ethers';
+import { PayableOverrides } from '../src/common/types';
 import { expect } from 'chai';
 import { buildTradeOverrides } from '../src/contracts-api/utils';
 import { TradeAction } from '../src/common/types';
@@ -8,9 +8,9 @@ describe('buildTradeOverrides', () => {
     const token = '0x123';
     const tokenEth = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
     const tradeActions = [
-      { amount: BigNumber.from(1) },
-      { amount: BigNumber.from(2) },
-      { amount: BigNumber.from(3) },
+      { amount: 1n },
+      { amount: 2n },
+      { amount: 3n },
     ];
     const overrides: PayableOverrides = { gasLimit: 1000000 };
     expect(

--- a/tests/encoders.spec.ts
+++ b/tests/encoders.spec.ts
@@ -15,7 +15,7 @@ import {
 } from '../src/strategy-management/';
 import { DecodedStrategy, EncodedStrategy } from '../src/common/types';
 import sinon, { SinonStubbedInstance } from 'sinon';
-import { BigNumber, Decimal } from '../src/utils/numerics';
+import { Decimal } from '../src/utils/numerics';
 import { Decimals } from '../src/utils/decimals';
 import { isAlmostEqual } from './test-utils';
 
@@ -48,7 +48,7 @@ describe('encoders', () => {
         highestRate: '1',
         marginalRate: '1',
       };
-      const encodedOrder = encodeOrder(order, BigNumber.from('200'));
+      const encodedOrder = encodeOrder(order, BigInt('200'));
       expect(encodedOrder.y.toString()).to.equal('100');
       expect(encodedOrder.z.toString()).to.equal('200');
       expect(encodedOrder.A.toString()).to.equal('82442111944226');
@@ -743,8 +743,8 @@ describe('encoders', () => {
     it('should convert a DecodedStrategy object to a Strategy object', async () => {
       decimalsStub.fetchDecimals.onCall(0).resolves(18).onCall(1).resolves(6);
 
-      const decodedStrategy: DecodedStrategy & { id: BigNumber } = {
-        id: BigNumber.from(0),
+      const decodedStrategy: DecodedStrategy & { id: bigint } = {
+        id: 0n,
         token0: '0x6b175474e89094c44da98b954eedeac495271d0f',
         token1: '0x57ab1e02fee23774580c119740129eac7081e9d3',
         order0: {
@@ -776,27 +776,27 @@ describe('encoders', () => {
       };
 
       const decodedWithEncodedField: DecodedStrategy & {
-        id: BigNumber;
+        id: bigint;
         encoded: EncodedStrategy;
       } =
         // @ts-ignore
         {
           ...decodedStrategy,
           encoded: {
-            id: BigNumber.from(0),
+            id: 0n,
             token0: 'abc',
             token1: 'xyz',
             order0: {
-              y: BigNumber.from(0),
-              z: BigNumber.from(0),
-              A: BigNumber.from(0),
-              B: BigNumber.from(0),
+              y: 0n,
+              z: 0n,
+              A: 0n,
+              B: 0n,
             },
             order1: {
-              y: BigNumber.from(0),
-              z: BigNumber.from(0),
-              A: BigNumber.from(0),
-              B: BigNumber.from(0),
+              y: 0n,
+              z: 0n,
+              A: 0n,
+              B: 0n,
             },
           },
         };

--- a/tests/reader.spec.ts
+++ b/tests/reader.spec.ts
@@ -6,7 +6,6 @@ import { MulticallService, MultiCall } from '../src/contracts-api/utils';
 import { Multicall } from '../src/abis/types';
 import {
   EncodedStrategy,
-  TradeData,
   TradingFeeUpdate,
   TokenPair,
 } from '../src/common/types';
@@ -53,16 +52,6 @@ describe('Reader', () => {
     },
   };
 
-  const mockTradeData: TradeData = {
-    trader: '0x789',
-    sourceToken: '0x123',
-    targetToken: '0x456',
-    sourceAmount: '1000',
-    targetAmount: '2000',
-    tradingFeeAmount: '10',
-    byTargetAmount: true,
-  };
-
   const mockTradingFeeUpdate: TradingFeeUpdate = ['0x123', '0x456', 100];
 
   beforeEach(() => {
@@ -79,11 +68,6 @@ describe('Reader', () => {
                 return {
                   name: 'StrategyCreated',
                   args: mockEncodedStrategy,
-                };
-              case '0x456': // TokensTraded
-                return {
-                  name: 'TokensTraded',
-                  args: mockTradeData,
                 };
               case '0x789': // TradingFeePPMUpdated
                 return {
@@ -142,10 +126,10 @@ describe('Reader', () => {
               {
                 blockNumber: block,
                 logIndex: 1,
-                topics: ['0x456'], // TokensTraded
+                topics: ['0x789'], // TradingFeePPMUpdated
                 data: '0x',
                 blockHash: '0x123',
-                transactionIndex: 1,
+                transactionIndex: 2,
                 removed: false,
                 address: '0x123',
                 transactionHash: '0x456',
@@ -224,9 +208,6 @@ describe('Reader', () => {
       // Verify event types and data
       expect(events[0].type).to.equal('StrategyCreated');
       expect(events[0].data).to.deep.equal(mockEncodedStrategy);
-
-      expect(events[1].type).to.equal('TokensTraded');
-      expect(events[1].data).to.deep.equal(mockTradeData);
 
       expect(events[2].type).to.equal('TradingFeePPMUpdated');
       expect(events[2].data).to.equal(100);

--- a/tests/reader.spec.ts
+++ b/tests/reader.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { BigNumber } from '../src/utils/numerics';
 import Reader from '../src/contracts-api/Reader';
 import { Contracts } from '../src/contracts-api/Contracts';
 import { MulticallService, MultiCall } from '../src/contracts-api/utils';
@@ -35,20 +34,20 @@ describe('Reader', () => {
   let mockMulticallService: MockMulticallService;
 
   const mockEncodedStrategy: EncodedStrategy = {
-    id: BigNumber.from(1),
+    id: 1n,
     token0: '0x123',
     token1: '0x456',
     order0: {
-      y: BigNumber.from(100),
-      z: BigNumber.from(200),
-      A: BigNumber.from(300),
-      B: BigNumber.from(400),
+      y: 100n,
+      z: 200n,
+      A: 300n,
+      B: 400n,
     },
     order1: {
-      y: BigNumber.from(500),
-      z: BigNumber.from(600),
-      A: BigNumber.from(700),
-      B: BigNumber.from(800),
+      y: 500n,
+      z: 600n,
+      A: 700n,
+      B: 800n,
     },
   };
 
@@ -58,7 +57,7 @@ describe('Reader', () => {
     // Create mock contracts with necessary methods
     mockContracts = {
       carbonController: {
-        address: '0x123',
+        target: '0x123',
         interface: {
           parseLog: (log: { topics: string[]; data: string }) => {
             // Mock event parsing based on topics
@@ -88,7 +87,8 @@ describe('Reader', () => {
             }
           },
         },
-      },
+        strategiesByPair: async () => [] as any,
+      } as any,
       provider: {
         getLogs: async ({
           fromBlock,
@@ -98,23 +98,13 @@ describe('Reader', () => {
           toBlock: number;
         }) => {
           // Mock logs based on block range
-          const logs: {
-            blockNumber: number;
-            logIndex: number;
-            topics: string[];
-            data: string;
-            blockHash: string;
-            transactionIndex: number;
-            removed: boolean;
-            address: string;
-            transactionHash: string;
-          }[] = [];
+          const logs: any[] = [];
           for (let block = fromBlock; block <= toBlock; block++) {
             // Add multiple events per block with different log indices
             logs.push(
               {
                 blockNumber: block,
-                logIndex: 0,
+                index: 0,
                 topics: ['0x123'], // StrategyCreated
                 data: '0x',
                 blockHash: '0x123',
@@ -125,7 +115,7 @@ describe('Reader', () => {
               },
               {
                 blockNumber: block,
-                logIndex: 1,
+                index: 1,
                 topics: ['0x789'], // TradingFeePPMUpdated
                 data: '0x',
                 blockHash: '0x123',
@@ -136,7 +126,7 @@ describe('Reader', () => {
               },
               {
                 blockNumber: block,
-                logIndex: 2,
+                index: 2,
                 topics: ['0x789'], // TradingFeePPMUpdated
                 data: '0x',
                 blockHash: '0x123',
@@ -147,7 +137,7 @@ describe('Reader', () => {
               },
               {
                 blockNumber: block,
-                logIndex: 3,
+                index: 3,
                 topics: ['0xabc'], // PairTradingFeePPMUpdated
                 data: '0x',
                 blockHash: '0x123',
@@ -227,7 +217,7 @@ describe('Reader', () => {
         return [
           {
             blockNumber: 1,
-            logIndex: 0,
+            index: 0,
             topics: ['0xinvalid'], // Invalid event type
             data: '0x',
             blockHash: '0x123',
@@ -238,7 +228,7 @@ describe('Reader', () => {
           },
           {
             blockNumber: 1,
-            logIndex: 1,
+            index: 1,
             topics: ['0x123'], // Valid event
             data: '0x',
             blockHash: '0x123',
@@ -247,7 +237,7 @@ describe('Reader', () => {
             address: '0x123',
             transactionHash: '0x456',
           },
-        ];
+        ] as any;
       };
 
       const events = await reader.getEvents(1, 1, 1);
@@ -274,7 +264,7 @@ describe('Reader', () => {
   describe('strategiesByPair', () => {
     it('should return empty array when no strategies are found', async () => {
       // Override the mock contracts to return empty array
-      mockContracts.carbonController.strategiesByPair = async () => [];
+      (mockContracts.carbonController as any).strategiesByPair = async () => [];
 
       const strategies = await reader.strategiesByPair('0x123', '0x456');
       expect(strategies.length).to.equal(0);
@@ -284,47 +274,47 @@ describe('Reader', () => {
       // Create mock strategies in the correct format
       const mockStrategies: StrategyStructOutput[] = [
         [
-          BigNumber.from(1),
+          1n,
           '0xowner',
           ['0x123', '0x456'],
           [
             [
-              BigNumber.from(100),
-              BigNumber.from(200),
-              BigNumber.from(300),
-              BigNumber.from(400),
+              100n,
+              200n,
+              300n,
+              400n,
             ] as OrderStructOutput,
             [
-              BigNumber.from(500),
-              BigNumber.from(600),
-              BigNumber.from(700),
-              BigNumber.from(800),
+              500n,
+              600n,
+              700n,
+              800n,
             ] as OrderStructOutput,
           ],
         ] as StrategyStructOutput,
         [
-          BigNumber.from(2),
+          2n,
           '0xowner',
           ['0x123', '0x456'],
           [
             [
-              BigNumber.from(900),
-              BigNumber.from(1000),
-              BigNumber.from(1100),
-              BigNumber.from(1200),
+              900n,
+              1000n,
+              1100n,
+              1200n,
             ] as OrderStructOutput,
             [
-              BigNumber.from(1300),
-              BigNumber.from(1400),
-              BigNumber.from(1500),
-              BigNumber.from(1600),
+              1300n,
+              1400n,
+              1500n,
+              1600n,
             ] as OrderStructOutput,
           ],
         ] as StrategyStructOutput,
       ];
 
       // Override the mock contracts to return mock strategies
-      mockContracts.carbonController.strategiesByPair = async () =>
+      (mockContracts.carbonController as any).strategiesByPair = async () =>
         mockStrategies;
 
       const strategies = await reader.strategiesByPair('0x123', '0x456');
@@ -355,21 +345,21 @@ describe('Reader', () => {
         { length: 1500 },
         (_, i) =>
           [
-            BigNumber.from(i + 1),
+            BigInt(i + 1),
             '0xowner',
             ['0x123', '0x456'],
             [
               [
-                BigNumber.from(100),
-                BigNumber.from(200),
-                BigNumber.from(300),
-                BigNumber.from(400),
+                100n,
+                200n,
+                300n,
+                400n,
               ] as OrderStructOutput,
               [
-                BigNumber.from(500),
-                BigNumber.from(600),
-                BigNumber.from(700),
-                BigNumber.from(800),
+                500n,
+                600n,
+                700n,
+                800n,
               ] as OrderStructOutput,
             ],
           ] as StrategyStructOutput
@@ -379,11 +369,11 @@ describe('Reader', () => {
       let callCount = 0;
 
       // Override the mock contracts to return chunks of strategies
-      mockContracts.carbonController.strategiesByPair = async (
-        _,
-        __,
-        startIndex,
-        endIndex
+      (mockContracts.carbonController as any).strategiesByPair = async (
+        _: any,
+        __: any,
+        startIndex: any,
+        endIndex: any
       ) => {
         callCount++;
         return mockStrategies.slice(Number(startIndex), Number(endIndex));
@@ -429,21 +419,21 @@ describe('Reader', () => {
       token1: string
     ): StrategyStructOutput {
       return [
-        BigNumber.from(id),
+        BigInt(id),
         '0xowner',
         [token0, token1],
         [
           [
-            BigNumber.from(100),
-            BigNumber.from(200),
-            BigNumber.from(300),
-            BigNumber.from(400),
+            100n,
+            200n,
+            300n,
+            400n,
           ] as OrderStructOutput,
           [
-            BigNumber.from(500),
-            BigNumber.from(600),
-            BigNumber.from(700),
-            BigNumber.from(800),
+            500n,
+            600n,
+            700n,
+            800n,
           ] as OrderStructOutput,
         ],
       ] as StrategyStructOutput;
@@ -489,11 +479,11 @@ describe('Reader', () => {
       mockMulticallService.setResponses(firstChunkResponses);
 
       // Set up mock for subsequent chunks
-      mockContracts.carbonController.strategiesByPair = async (
-        token0: string,
-        token1: string,
-        startIndex: number,
-        endIndex: number
+      (mockContracts.carbonController as any).strategiesByPair = async (
+        token0: any,
+        token1: any,
+        startIndex: any,
+        endIndex: any
       ) => {
         const key = `${token0}-${token1}`;
         return mockStrategies[key].slice(Number(startIndex), Number(endIndex));
@@ -511,30 +501,26 @@ describe('Reader', () => {
       // Verify pair with single chunk (500 strategies)
       expect(results[1].pair).to.deep.equal(['0x789', '0xabc']);
       expect(results[1].strategies).to.have.length(500);
-      expect(results[1].strategies[0].id).to.deep.equal(BigNumber.from(1));
-      expect(results[1].strategies[499].id).to.deep.equal(BigNumber.from(500));
+      expect(results[1].strategies[0].id).to.deep.equal(1n);
+      expect(results[1].strategies[499].id).to.deep.equal(500n);
 
       // Verify pair with exactly one chunk (1000 strategies)
       expect(results[2].pair).to.deep.equal(['0xdef', '0xghi']);
       expect(results[2].strategies).to.have.length(1000);
-      expect(results[2].strategies[0].id).to.deep.equal(BigNumber.from(1));
-      expect(results[2].strategies[999].id).to.deep.equal(BigNumber.from(1000));
+      expect(results[2].strategies[0].id).to.deep.equal(1n);
+      expect(results[2].strategies[999].id).to.deep.equal(1000n);
 
       // Verify pair with two chunks (1500 strategies)
       expect(results[3].pair).to.deep.equal(['0xjkl', '0xmno']);
       expect(results[3].strategies).to.have.length(1500);
-      expect(results[3].strategies[0].id).to.deep.equal(BigNumber.from(1));
-      expect(results[3].strategies[1499].id).to.deep.equal(
-        BigNumber.from(1500)
-      );
+      expect(results[3].strategies[0].id).to.deep.equal(1n);
+      expect(results[3].strategies[1499].id).to.deep.equal(1500n);
 
       // Verify pair with three chunks (2500 strategies)
       expect(results[4].pair).to.deep.equal(['0xpqr', '0xstu']);
       expect(results[4].strategies).to.have.length(2500);
-      expect(results[4].strategies[0].id).to.deep.equal(BigNumber.from(1));
-      expect(results[4].strategies[2499].id).to.deep.equal(
-        BigNumber.from(2500)
-      );
+      expect(results[4].strategies[0].id).to.deep.equal(1n);
+      expect(results[4].strategies[2499].id).to.deep.equal(2500n);
     });
 
     it('should handle empty pairs array', async () => {

--- a/tests/toolkit.spec.ts
+++ b/tests/toolkit.spec.ts
@@ -3,42 +3,41 @@ import sinon from 'sinon';
 import { MarginalPriceOptions, Toolkit } from '../src/strategy-management';
 import { ChainCache } from '../src/chain-cache';
 import { EncodedStrategy, Strategy } from '../src/common/types';
-import { BigNumber } from '../src/utils/numerics';
-import { encodedStrategyBNToStr } from '../src/utils';
+import { encodedStrategyBigIntToStr } from '../src/utils';
 
 const encodedStrategies: EncodedStrategy[] = [
   {
-    id: BigNumber.from(0),
+    id: 0n,
     token0: 'abc',
     token1: 'xyz',
     order0: {
-      y: BigNumber.from(0),
-      z: BigNumber.from(0),
-      A: BigNumber.from(0),
-      B: BigNumber.from(0),
+      y: 0n,
+      z: 0n,
+      A: 0n,
+      B: 0n,
     },
     order1: {
-      y: BigNumber.from(0),
-      z: BigNumber.from(0),
-      A: BigNumber.from(0),
-      B: BigNumber.from(0),
+      y: 0n,
+      z: 0n,
+      A: 0n,
+      B: 0n,
     },
   },
   {
-    id: BigNumber.from(1),
+    id: 1n,
     token0: 'xyz',
     token1: 'abc',
     order0: {
-      y: BigNumber.from(1),
-      z: BigNumber.from(1),
-      A: BigNumber.from(1),
-      B: BigNumber.from(1),
+      y: 1n,
+      z: 1n,
+      A: 1n,
+      B: 1n,
     },
     order1: {
-      y: BigNumber.from(1),
-      z: BigNumber.from(1),
-      A: BigNumber.from(1),
-      B: BigNumber.from(1),
+      y: 1n,
+      z: 1n,
+      A: 1n,
+      B: 1n,
     },
   },
 ];
@@ -56,7 +55,7 @@ const expectedStrategies: Strategy[] = [
     sellPriceMarginal: '0',
     sellPriceHigh: '0',
     sellBudget: '0',
-    encoded: encodedStrategyBNToStr(encodedStrategies[0]),
+    encoded: encodedStrategyBigIntToStr(encodedStrategies[0]),
   },
   {
     id: '1',
@@ -73,7 +72,7 @@ const expectedStrategies: Strategy[] = [
     sellPriceMarginal: '19807040628566084398385987584',
     sellPriceHigh: '79228162514264337593543950336',
     sellBudget: '0.000000000000000001',
-    encoded: encodedStrategyBNToStr(encodedStrategies[1]),
+    encoded: encodedStrategyBigIntToStr(encodedStrategies[1]),
   },
 ];
 
@@ -671,7 +670,7 @@ describe('Toolkit', () => {
       const toolkit = new Toolkit(apiMock, cacheMock, decimalFetcher);
       const strategies = await toolkit.getStrategyById('0');
 
-      expect(apiMock.reader.strategy.calledWith(BigNumber.from('0'))).to.be
+      expect(apiMock.reader.strategy.calledWith(0n)).to.be
         .true;
       expect(strategies).to.deep.equal(expectedStrategies[0]);
     });

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import {
   formatUnits,
   parseUnits,
-  BigNumber,
   Decimal,
 } from '../src/utils/numerics';
 import {
@@ -343,7 +342,7 @@ describe('utils', () => {
   });
   describe('addFee', () => {
     it('should correctly add the fee', () => {
-      const amount = BigNumber.from(1000);
+      const amount = 1000n;
       const tradingFeePPM = 50000;
       const expected = '1053';
 
@@ -353,7 +352,7 @@ describe('utils', () => {
     });
 
     it('should return zero for zero amount', () => {
-      const amount = BigNumber.from(0);
+      const amount = 0n;
       const tradingFeePPM = 50000;
       const expected = '0';
 
@@ -363,7 +362,7 @@ describe('utils', () => {
     });
 
     it('should return the same amount for zero tradingFeePPM', () => {
-      const amount = BigNumber.from(1000);
+      const amount = 1000n;
       const tradingFeePPM = 0;
       const expected = '1000';
 
@@ -375,7 +374,7 @@ describe('utils', () => {
 
   describe('subtractFee', () => {
     it('subtracts fee correctly', () => {
-      const amount = BigNumber.from(10000000);
+      const amount = 10000000n;
       const tradingFeePPM = 5000;
       const result = subtractFee(amount, tradingFeePPM);
 
@@ -383,7 +382,7 @@ describe('utils', () => {
     });
 
     it('returns 0 when amount is 0', () => {
-      const amount = BigNumber.from(0);
+      const amount = 0n;
       const tradingFeePPM = 10000;
       const result = subtractFee(amount, tradingFeePPM);
 
@@ -391,7 +390,7 @@ describe('utils', () => {
     });
 
     it('returns the same amount when tradingFeePPM is 0', () => {
-      const amount = BigNumber.from(1000000000000000000n);
+      const amount = 1000000000000000000n;
       const tradingFeePPM = 0;
       const result = subtractFee(amount, tradingFeePPM);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@adraffy/ens-normalize@1.10.1":
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz#63430d04bd8c5e74f8d7d049338f1cd9d4f02069"
+  integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
+
 "@babel/code-frame@^7.10.4":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.23.5.tgz#9009b69a8c602293476ad598ff53e4562e15c244"
@@ -101,348 +106,6 @@
   dependencies:
     "@eslint/core" "^0.13.0"
     levn "^0.4.1"
-
-"@ethersproject/abi@5.8.0", "@ethersproject/abi@^5.7.0", "@ethersproject/abi@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.8.0.tgz#e79bb51940ac35fe6f3262d7fe2cdb25ad5f07d9"
-  integrity sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==
-  dependencies:
-    "@ethersproject/address" "^5.8.0"
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/constants" "^5.8.0"
-    "@ethersproject/hash" "^5.8.0"
-    "@ethersproject/keccak256" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    "@ethersproject/strings" "^5.8.0"
-
-"@ethersproject/abstract-provider@5.8.0", "@ethersproject/abstract-provider@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz#7581f9be601afa1d02b95d26b9d9840926a35b0c"
-  integrity sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==
-  dependencies:
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/networks" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    "@ethersproject/transactions" "^5.8.0"
-    "@ethersproject/web" "^5.8.0"
-
-"@ethersproject/abstract-signer@5.8.0", "@ethersproject/abstract-signer@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz#8d7417e95e4094c1797a9762e6789c7356db0754"
-  integrity sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.8.0"
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-
-"@ethersproject/address@5.8.0", "@ethersproject/address@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.8.0.tgz#3007a2c352eee566ad745dca1dbbebdb50a6a983"
-  integrity sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==
-  dependencies:
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/keccak256" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/rlp" "^5.8.0"
-
-"@ethersproject/base64@5.8.0", "@ethersproject/base64@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.8.0.tgz#61c669c648f6e6aad002c228465d52ac93ee83eb"
-  integrity sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==
-  dependencies:
-    "@ethersproject/bytes" "^5.8.0"
-
-"@ethersproject/basex@5.8.0", "@ethersproject/basex@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.8.0.tgz#1d279a90c4be84d1c1139114a1f844869e57d03a"
-  integrity sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==
-  dependencies:
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-
-"@ethersproject/bignumber@5.8.0", "@ethersproject/bignumber@^5.7.0", "@ethersproject/bignumber@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.8.0.tgz#c381d178f9eeb370923d389284efa19f69efa5d7"
-  integrity sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==
-  dependencies:
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    bn.js "^5.2.1"
-
-"@ethersproject/bytes@5.8.0", "@ethersproject/bytes@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.8.0.tgz#9074820e1cac7507a34372cadeb035461463be34"
-  integrity sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==
-  dependencies:
-    "@ethersproject/logger" "^5.8.0"
-
-"@ethersproject/constants@5.8.0", "@ethersproject/constants@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.8.0.tgz#12f31c2f4317b113a4c19de94e50933648c90704"
-  integrity sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==
-  dependencies:
-    "@ethersproject/bignumber" "^5.8.0"
-
-"@ethersproject/contracts@5.8.0", "@ethersproject/contracts@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.8.0.tgz#243a38a2e4aa3e757215ea64e276f8a8c9d8ed73"
-  integrity sha512-0eFjGz9GtuAi6MZwhb4uvUM216F38xiuR0yYCjKJpNfSEy4HUM8hvqqBj9Jmm0IUz8l0xKEhWwLIhPgxNY0yvQ==
-  dependencies:
-    "@ethersproject/abi" "^5.8.0"
-    "@ethersproject/abstract-provider" "^5.8.0"
-    "@ethersproject/abstract-signer" "^5.8.0"
-    "@ethersproject/address" "^5.8.0"
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/constants" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    "@ethersproject/transactions" "^5.8.0"
-
-"@ethersproject/hash@5.8.0", "@ethersproject/hash@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.8.0.tgz#b8893d4629b7f8462a90102572f8cd65a0192b4c"
-  integrity sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==
-  dependencies:
-    "@ethersproject/abstract-signer" "^5.8.0"
-    "@ethersproject/address" "^5.8.0"
-    "@ethersproject/base64" "^5.8.0"
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/keccak256" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    "@ethersproject/strings" "^5.8.0"
-
-"@ethersproject/hdnode@5.8.0", "@ethersproject/hdnode@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.8.0.tgz#a51ae2a50bcd48ef6fd108c64cbae5e6ff34a761"
-  integrity sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==
-  dependencies:
-    "@ethersproject/abstract-signer" "^5.8.0"
-    "@ethersproject/basex" "^5.8.0"
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/pbkdf2" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    "@ethersproject/sha2" "^5.8.0"
-    "@ethersproject/signing-key" "^5.8.0"
-    "@ethersproject/strings" "^5.8.0"
-    "@ethersproject/transactions" "^5.8.0"
-    "@ethersproject/wordlists" "^5.8.0"
-
-"@ethersproject/json-wallets@5.8.0", "@ethersproject/json-wallets@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.8.0.tgz#d18de0a4cf0f185f232eb3c17d5e0744d97eb8c9"
-  integrity sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==
-  dependencies:
-    "@ethersproject/abstract-signer" "^5.8.0"
-    "@ethersproject/address" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/hdnode" "^5.8.0"
-    "@ethersproject/keccak256" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/pbkdf2" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    "@ethersproject/random" "^5.8.0"
-    "@ethersproject/strings" "^5.8.0"
-    "@ethersproject/transactions" "^5.8.0"
-    aes-js "3.0.0"
-    scrypt-js "3.0.1"
-
-"@ethersproject/keccak256@5.8.0", "@ethersproject/keccak256@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.8.0.tgz#d2123a379567faf2d75d2aaea074ffd4df349e6a"
-  integrity sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==
-  dependencies:
-    "@ethersproject/bytes" "^5.8.0"
-    js-sha3 "0.8.0"
-
-"@ethersproject/logger@5.8.0", "@ethersproject/logger@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.8.0.tgz#f0232968a4f87d29623a0481690a2732662713d6"
-  integrity sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==
-
-"@ethersproject/networks@5.8.0", "@ethersproject/networks@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.8.0.tgz#8b4517a3139380cba9fb00b63ffad0a979671fde"
-  integrity sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==
-  dependencies:
-    "@ethersproject/logger" "^5.8.0"
-
-"@ethersproject/pbkdf2@5.8.0", "@ethersproject/pbkdf2@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.8.0.tgz#cd2621130e5dd51f6a0172e63a6e4a0c0a0ec37e"
-  integrity sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==
-  dependencies:
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/sha2" "^5.8.0"
-
-"@ethersproject/properties@5.8.0", "@ethersproject/properties@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.8.0.tgz#405a8affb6311a49a91dabd96aeeae24f477020e"
-  integrity sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==
-  dependencies:
-    "@ethersproject/logger" "^5.8.0"
-
-"@ethersproject/providers@5.8.0", "@ethersproject/providers@^5.7.2":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.8.0.tgz#6c2ae354f7f96ee150439f7de06236928bc04cb4"
-  integrity sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.8.0"
-    "@ethersproject/abstract-signer" "^5.8.0"
-    "@ethersproject/address" "^5.8.0"
-    "@ethersproject/base64" "^5.8.0"
-    "@ethersproject/basex" "^5.8.0"
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/constants" "^5.8.0"
-    "@ethersproject/hash" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/networks" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    "@ethersproject/random" "^5.8.0"
-    "@ethersproject/rlp" "^5.8.0"
-    "@ethersproject/sha2" "^5.8.0"
-    "@ethersproject/strings" "^5.8.0"
-    "@ethersproject/transactions" "^5.8.0"
-    "@ethersproject/web" "^5.8.0"
-    bech32 "1.1.4"
-    ws "8.18.0"
-
-"@ethersproject/random@5.8.0", "@ethersproject/random@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.8.0.tgz#1bced04d49449f37c6437c701735a1a022f0057a"
-  integrity sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==
-  dependencies:
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-
-"@ethersproject/rlp@5.8.0", "@ethersproject/rlp@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.8.0.tgz#5a0d49f61bc53e051532a5179472779141451de5"
-  integrity sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==
-  dependencies:
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-
-"@ethersproject/sha2@5.8.0", "@ethersproject/sha2@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.8.0.tgz#8954a613bb78dac9b46829c0a95de561ef74e5e1"
-  integrity sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==
-  dependencies:
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    hash.js "1.1.7"
-
-"@ethersproject/signing-key@5.8.0", "@ethersproject/signing-key@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.8.0.tgz#9797e02c717b68239c6349394ea85febf8893119"
-  integrity sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==
-  dependencies:
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    bn.js "^5.2.1"
-    elliptic "6.6.1"
-    hash.js "1.1.7"
-
-"@ethersproject/solidity@5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.8.0.tgz#429bb9fcf5521307a9448d7358c26b93695379b9"
-  integrity sha512-4CxFeCgmIWamOHwYN9d+QWGxye9qQLilpgTU0XhYs1OahkclF+ewO+3V1U0mvpiuQxm5EHHmv8f7ClVII8EHsA==
-  dependencies:
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/keccak256" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/sha2" "^5.8.0"
-    "@ethersproject/strings" "^5.8.0"
-
-"@ethersproject/strings@5.8.0", "@ethersproject/strings@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.8.0.tgz#ad79fafbf0bd272d9765603215ac74fd7953908f"
-  integrity sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==
-  dependencies:
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/constants" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-
-"@ethersproject/transactions@5.8.0", "@ethersproject/transactions@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.8.0.tgz#1e518822403abc99def5a043d1c6f6fe0007e46b"
-  integrity sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==
-  dependencies:
-    "@ethersproject/address" "^5.8.0"
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/constants" "^5.8.0"
-    "@ethersproject/keccak256" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    "@ethersproject/rlp" "^5.8.0"
-    "@ethersproject/signing-key" "^5.8.0"
-
-"@ethersproject/units@5.8.0", "@ethersproject/units@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.8.0.tgz#c12f34ba7c3a2de0e9fa0ed0ee32f3e46c5c2c6a"
-  integrity sha512-lxq0CAnc5kMGIiWW4Mr041VT8IhNM+Pn5T3haO74XZWFulk7wH1Gv64HqE96hT4a7iiNMdOCFEBgaxWuk8ETKQ==
-  dependencies:
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/constants" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-
-"@ethersproject/wallet@5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.8.0.tgz#49c300d10872e6986d953e8310dc33d440da8127"
-  integrity sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.8.0"
-    "@ethersproject/abstract-signer" "^5.8.0"
-    "@ethersproject/address" "^5.8.0"
-    "@ethersproject/bignumber" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/hash" "^5.8.0"
-    "@ethersproject/hdnode" "^5.8.0"
-    "@ethersproject/json-wallets" "^5.8.0"
-    "@ethersproject/keccak256" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    "@ethersproject/random" "^5.8.0"
-    "@ethersproject/signing-key" "^5.8.0"
-    "@ethersproject/transactions" "^5.8.0"
-    "@ethersproject/wordlists" "^5.8.0"
-
-"@ethersproject/web@5.8.0", "@ethersproject/web@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.8.0.tgz#3e54badc0013b7a801463a7008a87988efce8a37"
-  integrity sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==
-  dependencies:
-    "@ethersproject/base64" "^5.8.0"
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    "@ethersproject/strings" "^5.8.0"
-
-"@ethersproject/wordlists@5.8.0", "@ethersproject/wordlists@^5.8.0":
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.8.0.tgz#7a5654ee8d1bb1f4dbe43f91d217356d650ad821"
-  integrity sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==
-  dependencies:
-    "@ethersproject/bytes" "^5.8.0"
-    "@ethersproject/hash" "^5.8.0"
-    "@ethersproject/logger" "^5.8.0"
-    "@ethersproject/properties" "^5.8.0"
-    "@ethersproject/strings" "^5.8.0"
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"
@@ -555,6 +218,18 @@
   dependencies:
     lodash "^4.17.16"
     uuid "^7.0.3"
+
+"@noble/curves@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
+  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
+  dependencies:
+    "@noble/hashes" "1.3.2"
+
+"@noble/hashes@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
+  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -771,10 +446,10 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
-"@typechain/ethers-v5@^11.1.2":
-  version "11.1.2"
-  resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-11.1.2.tgz#82510c1744f37a2f906b9e0532ac18c0b74ffe69"
-  integrity sha512-ID6pqWkao54EuUQa0P5RgjvfA3MYqxUQKpbGKERbsjBW5Ra7EIXvbMlPp2pcP5IAdUkyMCFYsP2SN5q7mPdLDQ==
+"@typechain/ethers-v6@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@typechain/ethers-v6/-/ethers-v6-0.5.1.tgz#42fe214a19a8b687086c93189b301e2b878797ea"
+  integrity sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==
   dependencies:
     lodash "^4.17.15"
     ts-essentials "^7.0.1"
@@ -812,6 +487,13 @@
   integrity sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==
   dependencies:
     undici-types "~6.20.0"
+
+"@types/node@22.7.5":
+  version "22.7.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
+  integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/prettier@^2.1.1":
   version "2.7.2"
@@ -944,10 +626,10 @@ acorn@^8.4.1, acorn@^8.8.2:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
   integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
 
-aes-js@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
-  integrity sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==
+aes-js@4.0.0-beta.5:
+  version "4.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-4.0.0-beta.5.tgz#8d2452c52adedebc3a3e28465d858c11ca315873"
+  integrity sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==
 
 ajv@^6.12.4:
   version "6.12.6"
@@ -1031,25 +713,10 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-bech32@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
-  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
-
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
-
-bn.js@^4.11.9:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
-  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
-
-bn.js@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
-  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 body-parser@^2.2.0:
   version "2.2.0"
@@ -1087,11 +754,6 @@ braces@^3.0.3, braces@~3.0.2:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
-
-brorand@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
-  integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
 browser-stdout@^1.3.1:
   version "1.3.1"
@@ -1370,19 +1032,6 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-elliptic@6.6.1:
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
-  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
-  dependencies:
-    bn.js "^4.11.9"
-    brorand "^1.1.0"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.1"
-    inherits "^2.0.4"
-    minimalistic-assert "^1.0.1"
-    minimalistic-crypto-utils "^1.0.1"
-
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -1539,41 +1188,18 @@ etag@^1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-ethers@^5.8.0:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.8.0.tgz#97858dc4d4c74afce83ea7562fe9493cedb4d377"
-  integrity sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==
+ethers@^6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.15.0.tgz#2980f2a3baf0509749b7e21f8692fa8a8349c0e3"
+  integrity sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==
   dependencies:
-    "@ethersproject/abi" "5.8.0"
-    "@ethersproject/abstract-provider" "5.8.0"
-    "@ethersproject/abstract-signer" "5.8.0"
-    "@ethersproject/address" "5.8.0"
-    "@ethersproject/base64" "5.8.0"
-    "@ethersproject/basex" "5.8.0"
-    "@ethersproject/bignumber" "5.8.0"
-    "@ethersproject/bytes" "5.8.0"
-    "@ethersproject/constants" "5.8.0"
-    "@ethersproject/contracts" "5.8.0"
-    "@ethersproject/hash" "5.8.0"
-    "@ethersproject/hdnode" "5.8.0"
-    "@ethersproject/json-wallets" "5.8.0"
-    "@ethersproject/keccak256" "5.8.0"
-    "@ethersproject/logger" "5.8.0"
-    "@ethersproject/networks" "5.8.0"
-    "@ethersproject/pbkdf2" "5.8.0"
-    "@ethersproject/properties" "5.8.0"
-    "@ethersproject/providers" "5.8.0"
-    "@ethersproject/random" "5.8.0"
-    "@ethersproject/rlp" "5.8.0"
-    "@ethersproject/sha2" "5.8.0"
-    "@ethersproject/signing-key" "5.8.0"
-    "@ethersproject/solidity" "5.8.0"
-    "@ethersproject/strings" "5.8.0"
-    "@ethersproject/transactions" "5.8.0"
-    "@ethersproject/units" "5.8.0"
-    "@ethersproject/wallet" "5.8.0"
-    "@ethersproject/web" "5.8.0"
-    "@ethersproject/wordlists" "5.8.0"
+    "@adraffy/ens-normalize" "1.10.1"
+    "@noble/curves" "1.2.0"
+    "@noble/hashes" "1.3.2"
+    "@types/node" "22.7.5"
+    aes-js "4.0.0-beta.5"
+    tslib "2.7.0"
+    ws "8.17.1"
 
 events@^3.3.0:
   version "3.3.0"
@@ -1883,14 +1509,6 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
-  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
-  dependencies:
-    inherits "^2.0.3"
-    minimalistic-assert "^1.0.1"
-
 hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
@@ -1902,15 +1520,6 @@ he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-
-hmac-drbg@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
-  integrity sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==
-  dependencies:
-    hash.js "^1.0.3"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.1"
 
 http-errors@2.0.0, http-errors@^2.0.0:
   version "2.0.0"
@@ -1961,7 +1570,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2, inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2057,7 +1666,7 @@ jest-worker@^26.2.1:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-js-sha3@0.8.0, js-sha3@^0.8.0:
+js-sha3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
@@ -2217,16 +1826,6 @@ mime-types@^3.0.0, mime-types@^3.0.1:
   integrity sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==
   dependencies:
     mime-db "^1.54.0"
-
-minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
-  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
-
-minimalistic-crypto-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
-  integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
 minimatch@^3.0.4, minimatch@^3.1.2:
   version "3.1.2"
@@ -2601,11 +2200,6 @@ safe-buffer@5.2.1, safe-buffer@^5.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-scrypt-js@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
-  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
-
 semver@^7.6.0:
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
@@ -2900,6 +2494,11 @@ ts-node@^10.9.2:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
+tslib@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
+  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
+
 tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
@@ -2961,6 +2560,11 @@ typical@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
   integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
+
+undici-types@~6.19.2:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 undici-types@~6.20.0:
   version "6.20.0"
@@ -3051,10 +2655,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@8.18.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+ws@8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1189,9 +1189,9 @@ etag@^1.8.1:
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
 ethers@^6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.15.0.tgz#2980f2a3baf0509749b7e21f8692fa8a8349c0e3"
-  integrity sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.16.0.tgz#fff9b4f05d7a359c774ad6e91085a800f7fccf65"
+  integrity sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==
   dependencies:
     "@adraffy/ens-normalize" "1.10.1"
     "@noble/curves" "1.2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrate SDK to ethers v6 with BigInt-based numerics, refactor APIs and matchers, simplify ChainCache schema, and update demos/tests and build tooling accordingly.
> 
> - **Core Types & Numerics**:
>   - Replace `BigNumber` with native `bigint` across SDK (`common/types`, `utils/numerics`, `utils/serializers`, `utils/encoders`).
>   - Adjust encoders/match utilities to BigInt math and return types.
> - **Contracts API (ethers v6)**:
>   - Switch to ethers v6 (`Provider`, `Interface`, `TransactionRequest`) and event APIs (`getEvent`, bigint args).
>   - Update `Reader` multicall targets (`contract.target`), fee getters return `number`.
>   - Update `Composer` populate calls and overrides to use `bigint`.
> - **Trade Matcher & Strategy Management**:
>   - Refactor match/trade logic to `bigint`; update Toolkit helpers and fee math.
> - **Chain Cache**:
>   - Bump scheme to `7`; simplify serialized dump (remove trades/blocks metadata), convert to `RetypeBigIntToString`.
>   - Add cache-miss handler flow; fix strategy updates/deletes using `bigint` IDs; change pair key separator to `_`.
> - **Adapters (Uni v3)**:
>   - Use `bigint` for addresses/fields; liquidity/tick calculations unchanged in behavior.
> - **Demo**:
>   - Update provider init to `new ethers.JsonRpcProvider` and event filter usage.
> - **Build & Deps**:
>   - Upgrade to TypeChain `ethers-v6`; move `ethers@^6` to peerDep; bump version to `0.0.126-DEV`.
> - **Tests**:
>   - Update all specs to `bigint`, new separators, ethers v6 behaviors, and revised ChainCache schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aba7401a2687f77981acb4f7effc4ba1ba5736f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->