### PR TITLE
Function `isOrderEncodable` should also verify that the order's B value is not zero

### DIFF
--- a/src/utils/encoders.ts
+++ b/src/utils/encoders.ts
@@ -71,8 +71,7 @@ export const encodeOrders = ([order0, order1]: [DecodedOrder, DecodedOrder]): [
 
 export const isOrderEncodable = (order: DecodedOrder): boolean => {
   try {
-    encodeOrder(order);
-    return true;
+    return encodeOrder(order).B > 0;
   } catch {
     return false;
   }

--- a/src/utils/encoders.ts
+++ b/src/utils/encoders.ts
@@ -71,7 +71,7 @@ export const encodeOrders = ([order0, order1]: [DecodedOrder, DecodedOrder]): [
 
 export const isOrderEncodable = (order: DecodedOrder): boolean => {
   try {
-    return encodeOrder(order).B > 0;
+    return encodeOrder(order).B > 0n;
   } catch {
     return false;
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates `isOrderEncodable` to return true only if `encodeOrder(order).B > 0n`, not merely if encoding succeeds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b97cc6defab0d1c7b8aa54dce4f6df12056f263. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->